### PR TITLE
ci: deny cargo doc warnings via new doc_check CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,3 +73,29 @@ jobs:
           components: rustfmt
       - name: Run cargo fmt
         run: cargo +nightly fmt --all -- --check
+
+  doc_check:
+    name: Doc
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-doc-${{ hashFiles('**/Cargo.toml') }}
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install Dependencies
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+      - name: Run cargo doc
+        run: |
+          cargo doc --no-deps 2>&1 | tee cargo-out
+          grep "(warning|error)" cargo-out


### PR DESCRIPTION
After some refactors, cargo doc began to produce warnings about broken intra-doc links. This was not caught by CI because these warnings are only produced by `cargo doc`.

Unfortunately, it doesn't seem like there's a good way to "deny warnings" in CI only with cargo doc. Either we deny with crate attributes or set up some custom CI check. The latter was implemented to make development of docs less painful.
