### PR TITLE
feat: add `ResWith` effect for transforming a resource with a function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,6 +882,7 @@ name = "bevy_pipe_affect"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "blake2",
  "proptest",
  "proptest-derive",
 ]
@@ -1308,6 +1309,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "blake3"
 version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1325,6 +1335,15 @@ name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "block2"
@@ -1719,6 +1738,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1765,6 +1794,17 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -2049,6 +2089,16 @@ dependencies = [
  "futures-io",
  "parking",
  "pin-project-lite",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -3732,6 +3782,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "svg_fmt"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4002,6 +4058,12 @@ name = "typeid"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e13db2e0ccd5e14a544e8a246ba2312cd25223f616442d7f2cb0e3db614236e"
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unarray"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ bevy = "0.15.2"
 [dev-dependencies]
 proptest = "1.6.0"
 proptest-derive = "0.5.1"
+blake2 = "0.10.2"

--- a/mvp-effects.md
+++ b/mvp-effects.md
@@ -1,6 +1,6 @@
 # Resource Effects
 - [x] `ResPut`
-- [ ] `ResWith`
+- [x] `ResWith`
 
 # Local?
 - [ ] `LocalPut`?

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -3,4 +3,4 @@
 //! [`Effect`]: crate::Effect
 
 mod resource;
-pub use resource::ResPut;
+pub use resource::{ResPut, ResWith};

--- a/src/effects/resource.rs
+++ b/src/effects/resource.rs
@@ -21,6 +21,7 @@ where
     }
 }
 
+/// [`Effect`] that transforms a `Resource` with the provided function.
 pub struct ResWith<F, R>
 where
     F: FnOnce(R) -> R,

--- a/src/effects/resource.rs
+++ b/src/effects/resource.rs
@@ -32,6 +32,20 @@ where
     phantom: PhantomData<R>,
 }
 
+impl<F, R> ResWith<F, R>
+where
+    F: FnOnce(R) -> R,
+    R: Resource + Clone,
+{
+    /// Construct a new [`ResWith`].
+    pub fn new(f: F) -> Self {
+        ResWith {
+            f,
+            phantom: PhantomData,
+        }
+    }
+}
+
 impl<F, R> Effect for ResWith<F, R>
 where
     F: FnOnce(R) -> R,

--- a/src/effects/resource.rs
+++ b/src/effects/resource.rs
@@ -22,6 +22,7 @@ where
 }
 
 /// [`Effect`] that transforms a `Resource` with the provided function.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub struct ResWith<F, R>
 where
     F: FnOnce(R) -> R,

--- a/src/effects/resource.rs
+++ b/src/effects/resource.rs
@@ -93,14 +93,14 @@ mod tests {
 
             prop_assume!(initial != put);
 
-            app.insert_resource(initial).add_systems(Update, (move || ResPut(put)).pipe(affect));
+            app.insert_resource(initial)
+                .add_systems(Update, (move || ResPut(put)).pipe(affect));
 
             prop_assert_eq!(app.world().resource::<NumberResource>(), &initial);
 
             app.update();
 
             prop_assert_eq!(app.world().resource::<NumberResource>(), &put);
-
         }
 
         #[test]
@@ -109,9 +109,10 @@ mod tests {
 
             let expected = one_way_number_fn_fn(salt.clone())(initial);
 
-            app.insert_resource(initial.clone()).add_systems(Update, (move || {
-            ResWith::new(one_way_number_fn_fn(salt.clone()))
-            }).pipe(affect));
+            app.insert_resource(initial.clone()).add_systems(
+                Update,
+                (move || ResWith::new(one_way_number_fn_fn(salt.clone()))).pipe(affect),
+            );
 
             prop_assert_eq!(app.world().resource::<NumberResource>(), &initial);
 

--- a/src/effects/resource.rs
+++ b/src/effects/resource.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
 
@@ -16,6 +18,27 @@ where
 
     fn affect(self, param: &mut <Self::MutParam as SystemParam>::Item<'_, '_>) {
         **param = self.0;
+    }
+}
+
+pub struct ResWith<R, F>
+where
+    F: FnMut(R) -> R,
+    R: Resource + Clone,
+{
+    f: F,
+    phantom: PhantomData<R>,
+}
+
+impl<R, F> Effect for ResWith<R, F>
+where
+    F: FnMut(R) -> R,
+    R: Resource + Clone,
+{
+    type MutParam = ResMut<'static, R>;
+
+    fn affect(mut self, param: &mut <Self::MutParam as SystemParam>::Item<'_, '_>) {
+        **param = (self.f)(param.clone());
     }
 }
 

--- a/src/effects/resource.rs
+++ b/src/effects/resource.rs
@@ -60,9 +60,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::hash::Hash;
-
-    use blake2::digest::consts::{U32, U4};
+    use blake2::digest::consts::U4;
     use blake2::{Blake2b, Digest};
     use proptest::prelude::*;
     use proptest_derive::Arbitrary;

--- a/src/effects/resource.rs
+++ b/src/effects/resource.rs
@@ -21,23 +21,23 @@ where
     }
 }
 
-pub struct ResWith<R, F>
+pub struct ResWith<F, R>
 where
-    F: FnMut(R) -> R,
+    F: FnOnce(R) -> R,
     R: Resource + Clone,
 {
     f: F,
     phantom: PhantomData<R>,
 }
 
-impl<R, F> Effect for ResWith<R, F>
+impl<F, R> Effect for ResWith<F, R>
 where
-    F: FnMut(R) -> R,
+    F: FnOnce(R) -> R,
     R: Resource + Clone,
 {
     type MutParam = ResMut<'static, R>;
 
-    fn affect(mut self, param: &mut <Self::MutParam as SystemParam>::Item<'_, '_>) {
+    fn affect(self, param: &mut <Self::MutParam as SystemParam>::Item<'_, '_>) {
         **param = (self.f)(param.clone());
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,5 @@
 //! `use bevy_pipe_affect::prelude::*;` to import common items.
 
-pub use crate::effects::ResPut;
+pub use crate::effects::{ResPut, ResWith};
 pub use crate::system_combinators::{affect, and_compose};
 pub use crate::{Effect, EffectOut};


### PR DESCRIPTION
In addition to `-Put` effects, the mvp will include `-With` effects, which use a "transformation" function to perform the update. This can be useful whenever the desired update is dependent on the current value. This will mostly see use on iterative system params like `Query`, but it has its purposes in `Res` as well, in case the user is producing many effects on the same resource in the same pipeline and wants those effects to compound properly.

Unfortunately, it does require that `R` implements `Clone`, for the time being. I looked for a way to update a `&mut T` with a `Fn(T) -> T` safely, but didn't find anything.