### PR TITLE
feat: derive common traits for `ResPut`

### DIFF
--- a/src/effects/resource.rs
+++ b/src/effects/resource.rs
@@ -4,6 +4,7 @@ use bevy::prelude::*;
 use crate::effect::Effect;
 
 /// [`Effect`] that sets a `Resource` to the provided value.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub struct ResPut<R>(pub R)
 where
     R: Resource;


### PR DESCRIPTION
These 6 traits should be derived wherever possible, they should have been included originally.
