### PR TITLE
feat: add `EventSend` effect for writing to `EventWriter`

### DIFF
--- a/mvp-effects.md
+++ b/mvp-effects.md
@@ -9,7 +9,7 @@
 *Need to research.. Could lead to confusing experience about which system the parameter is local to.*
 
 # Event Effects
-- [ ] `EventSend`
+- [x] `EventSend`
 
 # Query Effects
 - [ ] `QueryPut`

--- a/src/effects/event.rs
+++ b/src/effects/event.rs
@@ -1,4 +1,4 @@
-use bevy::ecs::event::{Event, EventWriter};
+use bevy::prelude::*;
 
 use crate::Effect;
 

--- a/src/effects/event.rs
+++ b/src/effects/event.rs
@@ -18,3 +18,38 @@ where
         param.send(self.0);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use proptest_derive::Arbitrary;
+
+    use super::*;
+    use crate::prelude::affect;
+
+    #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Event, Arbitrary)]
+    struct NumberEvent(u128);
+
+    proptest! {
+        #[test]
+        fn event_send_produces_events(events in prop::collection::vec(any::<NumberEvent>(), 1..10)) {
+            let mut app = App::new();
+
+            let mut events_clone = events.clone();
+            app.add_event::<NumberEvent>()
+                .add_systems(Update, (move || EventSend(events_clone.remove(0))).pipe(affect));
+
+            for expected in events {
+                app.update();
+
+                let events_in_update = app.world().resource::<Events<NumberEvent>>().iter_current_update_events().collect::<Vec<_>>();
+
+                prop_assert_eq!(events_in_update.len(), 1);
+
+                let event_sent = events_in_update.first().unwrap();
+
+                prop_assert_eq!(event_sent, &&expected);
+            }
+        }
+    }
+}

--- a/src/effects/event.rs
+++ b/src/effects/event.rs
@@ -1,0 +1,20 @@
+use bevy::ecs::event::{Event, EventWriter};
+
+use crate::Effect;
+
+/// [`Effect`] that sends an event `E` to the corresponding `EventWriter`.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct EventSend<E>(pub E)
+where
+    E: Event;
+
+impl<E> Effect for EventSend<E>
+where
+    E: Event,
+{
+    type MutParam = EventWriter<'static, E>;
+
+    fn affect(self, param: &mut <Self::MutParam as bevy::ecs::system::SystemParam>::Item<'_, '_>) {
+        param.send(self.0);
+    }
+}

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -6,3 +6,4 @@ mod resource;
 pub use resource::{ResPut, ResWith};
 
 mod event;
+pub use event::EventSend;

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -4,3 +4,5 @@
 
 mod resource;
 pub use resource::{ResPut, ResWith};
+
+mod event;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,5 @@
 //! `use bevy_pipe_affect::prelude::*;` to import common items.
 
-pub use crate::effects::{ResPut, ResWith};
+pub use crate::effects::{EventSend, ResPut, ResWith};
 pub use crate::system_combinators::{affect, and_compose};
 pub use crate::{Effect, EffectOut};


### PR DESCRIPTION
This change users to ergonomically use bevy event resources with effects.