### PR TITLE
feat: add ComponentsPut and ComponentsWith effects

### DIFF
--- a/mvp-effects.md
+++ b/mvp-effects.md
@@ -11,9 +11,9 @@
 # Event Effects
 - [x] `EventSend`
 
-# Query Effects
-- [ ] `QueryPut`
-- [ ] `QueryWith`
+# Components Effects
+- [x] `ComponentsPut`
+- [x] `ComponentsWith`
 
 # QueryEntity Effects
 - [ ] `QueryEntityPut`

--- a/mvp-effects.md
+++ b/mvp-effects.md
@@ -15,9 +15,9 @@
 - [x] `ComponentsPut`
 - [x] `ComponentsWith`
 
-# QueryEntity Effects
-- [ ] `QueryEntityPut`
-- [ ] `QueryEntityWith`
+# EntityComponents Effects
+- [ ] `EntityComponentsPut`
+- [ ] `EntityComponentsWith`
 
 # Command Effects
 - [ ] `InsertResource`

--- a/src/effects/components.rs
+++ b/src/effects/components.rs
@@ -7,6 +7,9 @@ use bevy::utils::all_tuples;
 
 use crate::Effect;
 
+/// [`Effect`] that sets `Component`s of all entities in a query to the provided `Component` tuple.
+///
+/// Can be parameterized by a `QueryFilter` to narrow down the components updated.
 pub struct ComponentsPut<C, F = ()>
 where
     C: Clone,

--- a/src/effects/components.rs
+++ b/src/effects/components.rs
@@ -1,0 +1,52 @@
+use std::marker::PhantomData;
+
+use bevy::ecs::query::QueryFilter;
+use bevy::ecs::system::SystemParam;
+use bevy::prelude::*;
+use bevy::utils::all_tuples;
+
+use crate::Effect;
+
+pub struct ComponentsPut<C, F = ()>
+where
+    C: Clone,
+    F: QueryFilter,
+{
+    components: C,
+    filter: PhantomData<F>,
+}
+
+impl<C, F> ComponentsPut<C, F>
+where
+    C: Clone,
+    F: QueryFilter,
+{
+    /// Construct a new [`ComponentsPut`].
+    pub fn new(components: C) -> Self {
+        ComponentsPut {
+            components,
+            filter: PhantomData,
+        }
+    }
+}
+
+macro_rules! impl_effect_for_components_put {
+    ($(($C:ident, $c:ident, $r:ident)),*) => {
+        impl<$($C,)* F> Effect for ComponentsPut<($($C,)*), F>
+        where
+            $($C: Component + Clone),*,
+            F: QueryFilter + 'static,
+        {
+            type MutParam = Query<'static, 'static, ($(&'static mut $C,)*), F>;
+
+            fn affect(self, param: &mut <Self::MutParam as SystemParam>::Item<'_, '_>) {
+                let ($($c,)*) = self.components;
+                param.iter_mut().for_each(|($(mut $r,)*)| {
+                    $(*$r = $c.clone());*
+                });
+            }
+        }
+    }
+}
+
+all_tuples!(impl_effect_for_components_put, 1, 15, C, c, r);

--- a/src/effects/components.rs
+++ b/src/effects/components.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use bevy::ecs::query::{QueryFilter, ReadOnlyQueryData};
+use bevy::ecs::query::{QueryFilter, ReadOnlyQueryData, WorldQuery};
 use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
 use bevy::utils::all_tuples;
@@ -61,7 +61,7 @@ all_tuples!(impl_effect_for_components_put, 1, 15, C, c, r);
 /// Can be parameterized by a `QueryFilter` to narrow down the components updated.
 pub struct ComponentsWith<F, C, Data = (), Filter = ()>
 where
-    F: FnMut(C, Data) -> C,
+    F: for<'a> FnMut(C, <Data as WorldQuery>::Item<'a>) -> C,
     C: Clone,
     Data: ReadOnlyQueryData,
     Filter: QueryFilter,
@@ -74,7 +74,7 @@ where
 
 impl<F, C, Data, Filter> ComponentsWith<F, C, Data, Filter>
 where
-    F: FnMut(C, Data) -> C,
+    F: for<'a> FnMut(C, <Data as WorldQuery>::Item<'a>) -> C,
     C: Clone,
     Data: ReadOnlyQueryData,
     Filter: QueryFilter,

--- a/src/effects/components.rs
+++ b/src/effects/components.rs
@@ -10,19 +10,19 @@ use crate::Effect;
 /// [`Effect`] that sets `Component`s of all entities in a query to the provided `Component` tuple.
 ///
 /// Can be parameterized by a `QueryFilter` to narrow down the components updated.
-pub struct ComponentsPut<C, F = ()>
+pub struct ComponentsPut<C, Filter = ()>
 where
     C: Clone,
-    F: QueryFilter,
+    Filter: QueryFilter,
 {
     components: C,
-    filter: PhantomData<F>,
+    filter: PhantomData<Filter>,
 }
 
-impl<C, F> ComponentsPut<C, F>
+impl<C, Filter> ComponentsPut<C, Filter>
 where
     C: Clone,
-    F: QueryFilter,
+    Filter: QueryFilter,
 {
     /// Construct a new [`ComponentsPut`].
     pub fn new(components: C) -> Self {
@@ -35,12 +35,12 @@ where
 
 macro_rules! impl_effect_for_components_put {
     ($(($C:ident, $c:ident, $r:ident)),*) => {
-        impl<$($C,)* F> Effect for ComponentsPut<($($C,)*), F>
+        impl<$($C,)* Filter> Effect for ComponentsPut<($($C,)*), Filter>
         where
             $($C: Component + Clone),*,
-            F: QueryFilter + 'static,
+            Filter: QueryFilter + 'static,
         {
-            type MutParam = Query<'static, 'static, ($(&'static mut $C,)*), F>;
+            type MutParam = Query<'static, 'static, ($(&'static mut $C,)*), Filter>;
 
             fn affect(self, param: &mut <Self::MutParam as SystemParam>::Item<'_, '_>) {
                 let ($($c,)*) = self.components;

--- a/src/effects/components.rs
+++ b/src/effects/components.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use bevy::ecs::query::QueryFilter;
+use bevy::ecs::query::{QueryFilter, ReadOnlyQueryData};
 use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
 use bevy::utils::all_tuples;
@@ -53,3 +53,39 @@ macro_rules! impl_effect_for_components_put {
 }
 
 all_tuples!(impl_effect_for_components_put, 1, 15, C, c, r);
+
+/// [`Effect`] that transforms `Component`s of all entities in a query with the provided function.
+///
+/// Can be parameterized by a `ReadOnlyQueryData` to access additional query data in the function.
+///
+/// Can be parameterized by a `QueryFilter` to narrow down the components updated.
+pub struct ComponentsWith<F, C, Data = (), Filter = ()>
+where
+    F: FnMut(C, Data) -> C,
+    C: Clone,
+    Data: ReadOnlyQueryData,
+    Filter: QueryFilter,
+{
+    f: F,
+    components: PhantomData<C>,
+    data: PhantomData<Data>,
+    filter: PhantomData<Filter>,
+}
+
+impl<F, C, Data, Filter> ComponentsWith<F, C, Data, Filter>
+where
+    F: FnMut(C, Data) -> C,
+    C: Clone,
+    Data: ReadOnlyQueryData,
+    Filter: QueryFilter,
+{
+    /// Construct a new [`ComponentsWith`].
+    pub fn new(f: F) -> Self {
+        ComponentsWith {
+            f,
+            components: PhantomData,
+            data: PhantomData,
+            filter: PhantomData,
+        }
+    }
+}

--- a/src/effects/components.rs
+++ b/src/effects/components.rs
@@ -152,7 +152,10 @@ mod tests {
 
     proptest! {
         #[test]
-        fn components_put_overwrites_initial_state(test_bundles in proptest::collection::vec(any::<BundleToBeMarked<(NumberComponent<0>, NumberComponent<1>)>>(), 0..16), put: (NumberComponent<0>, NumberComponent<1>)) {
+        fn components_put_overwrites_initial_state(
+            test_bundles in proptest::collection::vec(any::<BundleToBeMarked<(NumberComponent<0>, NumberComponent<1>)>>(), 0..16),
+            put: (NumberComponent<0>, NumberComponent<1>)
+        ) {
             let mut app = App::new();
 
             let entities = test_bundles

--- a/src/effects/components.rs
+++ b/src/effects/components.rs
@@ -112,4 +112,4 @@ macro_rules! impl_effect_for_components_with {
     }
 }
 
-all_tuples!(impl_effect_for_components_with, 2, 2, C, c, r);
+all_tuples!(impl_effect_for_components_with, 1, 15, C, c, r);

--- a/src/effects/components.rs
+++ b/src/effects/components.rs
@@ -45,7 +45,7 @@ macro_rules! impl_effect_for_components_put {
             fn affect(self, param: &mut <Self::MutParam as SystemParam>::Item<'_, '_>) {
                 let ($($c,)*) = self.components;
                 param.iter_mut().for_each(|($(mut $r,)*)| {
-                    $(*$r = $c.clone());*
+                    $(*$r = $c.clone();)*
                 });
             }
         }

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -8,5 +8,7 @@ pub use resource::{ResPut, ResWith};
 mod event;
 pub use event::EventSend;
 
+mod components;
+
 #[cfg(test)]
 mod one_way_fn;

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -9,6 +9,7 @@ mod event;
 pub use event::EventSend;
 
 mod components;
+pub use components::{ComponentsPut, ComponentsWith};
 
 #[cfg(test)]
 mod one_way_fn;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,5 @@
 //! `use bevy_pipe_affect::prelude::*;` to import common items.
 
-pub use crate::effects::{EventSend, ResPut, ResWith};
+pub use crate::effects::{ComponentsPut, ComponentsWith, EventSend, ResPut, ResWith};
 pub use crate::system_combinators::{affect, and_compose};
 pub use crate::{Effect, EffectOut};


### PR DESCRIPTION
One of the most important side effects of bevy systems is updating the state of components. This is mostly done using the `Query` system parameter. This change introduces two effects for defining state transitions of components in queries: `ComponentsPut` and `ComponentsWith`:
- `ComponentsPut` sets a tuple of components to the provided values.
- `ComponentsWith` transforms a tuple of components with the provided function. This function can also be parameterized by some `ReadOnlyQueryData`.

These two apply their effects to every entity in a `Query`. They can be defined with a `QueryFilter` to make the query more specific. Even more specific entity-component effects will be provided in the future.
