### PR TITLE
test: move `Number`- test types to their own module

### DIFF
--- a/src/effects/components.rs
+++ b/src/effects/components.rs
@@ -120,11 +120,9 @@ mod tests {
     use proptest_derive::Arbitrary;
 
     use super::*;
+    use crate::effects::number_data::NumberComponent;
     use crate::effects::one_way_fn::OneWayFn;
     use crate::system_combinators::affect;
-
-    #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Component, Arbitrary)]
-    struct NumberComponent<const MARKER: usize>(u128);
 
     #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Component)]
     struct MarkerComponent;

--- a/src/effects/event.rs
+++ b/src/effects/event.rs
@@ -22,13 +22,10 @@ where
 #[cfg(test)]
 mod tests {
     use proptest::prelude::*;
-    use proptest_derive::Arbitrary;
 
     use super::*;
+    use crate::effects::number_data::NumberEvent;
     use crate::prelude::affect;
-
-    #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Event, Arbitrary)]
-    struct NumberEvent(u128);
 
     proptest! {
         #[test]

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -13,3 +13,6 @@ pub use components::{ComponentsPut, ComponentsWith};
 
 #[cfg(test)]
 mod one_way_fn;
+
+#[cfg(test)]
+mod number_data;

--- a/src/effects/number_data.rs
+++ b/src/effects/number_data.rs
@@ -1,0 +1,18 @@
+//! Test types for various `bevy` data classes, all storing numbers, all proptest-generatable.
+use bevy::prelude::*;
+use proptest_derive::Arbitrary;
+
+/// Test `Component` storing a number.
+///
+/// The const generic MARKER can be used to easily define as many component types as you need.
+/// i.e., `Numbercomponent<0>` and `NumberComponent<1>` are different components in `bevy`.
+#[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Component, Arbitrary)]
+pub struct NumberComponent<const MARKER: usize>(pub u128);
+
+/// Test `Event` storing a number.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Event, Arbitrary)]
+pub struct NumberEvent(pub u128);
+
+/// Test `Resource` storing a number.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Resource, Arbitrary)]
+pub struct NumberResource(pub u128);

--- a/src/effects/resource.rs
+++ b/src/effects/resource.rs
@@ -62,14 +62,11 @@ where
 #[cfg(test)]
 mod tests {
     use proptest::prelude::*;
-    use proptest_derive::Arbitrary;
 
     use super::*;
+    use crate::effects::number_data::NumberResource;
     use crate::effects::one_way_fn::OneWayFn;
     use crate::system_combinators::affect;
-
-    #[derive(Copy, Clone, Debug, PartialEq, Eq, Resource, Arbitrary)]
-    struct NumberResource(u128);
 
     proptest! {
         #[test]


### PR DESCRIPTION
`Effect` tests thus far have been using a common convention for defining test data for a variety of `bevy` data classes. They are all "Number" types, they all store a `u128` (so they can easily be used with `OneWayFn`), and they are all proptest-generatable. 

As more effects are added and tested, these test types will become generally useful. This change moves these types to a common location so they can be more easily re-used in future tests.
