### PR TITLE
test: extract common `ComponentsWith` test functions

### DIFF
--- a/src/effects/number_data.rs
+++ b/src/effects/number_data.rs
@@ -2,12 +2,59 @@
 use bevy::prelude::*;
 use proptest_derive::Arbitrary;
 
+use super::one_way_fn::OneWayFn;
+
 /// Test `Component` storing a number.
 ///
 /// The const generic MARKER can be used to easily define as many component types as you need.
 /// i.e., `Numbercomponent<0>` and `NumberComponent<1>` are different components in `bevy`.
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Component, Arbitrary)]
 pub struct NumberComponent<const MARKER: usize>(pub u128);
+
+/// Returns a transform for a pair of [`NumberComponent`]s using the [`OneWayFn`]s.
+///
+/// Can be used for validating a `-ComponentsWith` that uses
+/// [`two_number_components_one_way_transform_with_void_query_data`].
+pub fn two_number_components_one_way_transform(
+    f0: OneWayFn,
+    f1: OneWayFn,
+) -> impl Fn((NumberComponent<0>, NumberComponent<1>)) -> (NumberComponent<0>, NumberComponent<1>) {
+    move |(NumberComponent(n0), NumberComponent(n1))| {
+        (NumberComponent(f0.call(n0)), NumberComponent(f1.call(n1)))
+    }
+}
+
+/// Returns a transform for a pair of [`NumberComponent`]s and () using the [`OneWayFn`]s.
+///
+/// Can be used as the function stored in a `-ComponentsWith` effect.
+pub fn two_number_components_one_way_transform_with_void_query_data(
+    f0: OneWayFn,
+    f1: OneWayFn,
+) -> impl Fn((NumberComponent<0>, NumberComponent<1>), ()) -> (NumberComponent<0>, NumberComponent<1>)
+{
+    move |(n0, n1), _| two_number_components_one_way_transform(f0, f1)((n0, n1))
+}
+
+/// Returns a function taking a [`NumberComponent`] with `MARKER=0` and returning a `MARKER=1`
+/// using the [`OneWayFn`].
+///
+/// Can be used for validating a `-ComponentsWith` that uses
+/// [`n0_query_data_to_n1_through_one_way_function`].
+pub fn n0_to_n1_through_one_way_function(
+    f: OneWayFn,
+) -> impl Fn(NumberComponent<0>) -> NumberComponent<1> {
+    move |NumberComponent(n)| NumberComponent(f.call(n))
+}
+
+/// Returns a function transforming a `(NumberComponent<1>,)` from a `&NumberComponent<0>` using
+/// the [`OneWayFn`].
+///
+/// Can be used as the function stored in a `-ComponentsWith` effect.
+pub fn n0_query_data_to_n1_through_one_way_function(
+    f: OneWayFn,
+) -> impl Fn((NumberComponent<1>,), &NumberComponent<0>) -> (NumberComponent<1>,) {
+    move |_, n0| (n0_to_n1_through_one_way_function(f)(*n0),)
+}
 
 /// Test `Event` storing a number.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Event, Arbitrary)]


### PR DESCRIPTION
The `ComponentsWith` tests currently create some ad-hoc closures to supply to the effect. However, in the future there will be an `EntityComponentsWith` effect which will have a very similar API. Being able to reuse these functions for `EntityComponentsWith` tests will reduce repeated code. So, this change extracts these closures into actual functions in the `number_data` test module.
