### PR TITLE
feat: add `EntityComponentsPut` and `EntityComponentsWith` effects

### DIFF
--- a/mvp-effects.md
+++ b/mvp-effects.md
@@ -16,8 +16,8 @@
 - [x] `ComponentsWith`
 
 # EntityComponents Effects
-- [ ] `EntityComponentsPut`
-- [ ] `EntityComponentsWith`
+- [x] `EntityComponentsPut`
+- [x] `EntityComponentsWith`
 
 # Command Effects
 - [ ] `InsertResource`

--- a/src/effects/entity_components.rs
+++ b/src/effects/entity_components.rs
@@ -1,0 +1,113 @@
+use std::marker::PhantomData;
+
+use bevy::ecs::query::{ReadOnlyQueryData, WorldQuery};
+use bevy::ecs::system::SystemParam;
+use bevy::prelude::*;
+use bevy::utils::all_tuples;
+
+use crate::Effect;
+
+/// [`Effect`] that sets the `Component`s of the provided entity to the provided `Component` tuple.
+///
+/// If an entity with these components cannot be found, logs an error.
+pub struct EntityComponentsPut<C> {
+    entity: Entity,
+    components: C,
+}
+
+impl<C> EntityComponentsPut<C> {
+    /// Construct a new [`EntityComponentsPut`].
+    pub fn new(entity: Entity, components: C) -> Self {
+        EntityComponentsPut { entity, components }
+    }
+}
+
+macro_rules! impl_effect_for_entity_components_put {
+    ($(($C:ident, $c:ident, $r:ident)),*) => {
+        impl<$($C),*> Effect for EntityComponentsPut<($($C,)*)>
+        where
+            $($C: Component,)*
+        {
+            type MutParam = Query<'static, 'static, ($(&'static mut $C,)*)>;
+
+            fn affect(self, param: &mut <Self::MutParam as SystemParam>::Item<'_, '_>) {
+                let ($(mut $r,)*) = match param.get_mut(self.entity) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        error!("unable to query entity in EntityComponentsPut: {e}");
+                        return ();
+                    }
+                };
+
+                let ($($c,)*) = self.components;
+
+                $(*$r = $c;)*
+            }
+        }
+    }
+}
+
+all_tuples!(impl_effect_for_entity_components_put, 1, 15, C, c, r);
+
+/// [`Effect`] that transforms the `Component`s of the provided entity with the provided function.
+///
+/// Can be parameterized by a `ReadOnlyQueryData` to access additional query data in the function.
+///
+/// If an entity with these components cannot be found, logs an error.
+pub struct EntityComponentsWith<F, C, Data = ()>
+where
+    F: for<'a> Fn(C, <Data as WorldQuery>::Item<'a>) -> C + Send + Sync,
+    C: Clone,
+    Data: ReadOnlyQueryData,
+{
+    entity: Entity,
+    f: F,
+    components: PhantomData<C>,
+    data: PhantomData<Data>,
+}
+
+impl<F, C, Data> EntityComponentsWith<F, C, Data>
+where
+    F: for<'a> Fn(C, <Data as WorldQuery>::Item<'a>) -> C + Send + Sync,
+    C: Clone,
+    Data: ReadOnlyQueryData,
+{
+    /// Construct a new [`EntityComponentsWith`].
+    pub fn new(entity: Entity, f: F) -> Self {
+        EntityComponentsWith {
+            entity,
+            f,
+            components: PhantomData,
+            data: PhantomData,
+        }
+    }
+}
+
+macro_rules! impl_effect_for_entity_components_with {
+    ($(($C:ident, $c:ident, $r:ident)),*) => {
+        impl<F, $($C,)* Data> Effect for EntityComponentsWith<F, ($($C,)*), Data>
+        where
+            F: for<'a> Fn(($($C,)*), <Data as WorldQuery>::Item<'a>) -> ($($C,)*) + Send + Sync,
+            $($C: Component + Clone,)*
+            Data: ReadOnlyQueryData + 'static,
+        {
+            type MutParam = Query<'static, 'static, (($(&'static mut $C,)*), Data)>;
+
+            fn affect(self, param: &mut <Self::MutParam as SystemParam>::Item<'_, '_>) {
+                let (($(mut $r,)*), data) = match param.get_mut(self.entity) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        error!("unable to query entity in EntityComponentsWith: {e}");
+                        return ();
+                    }
+                };
+                let cloned = ($($r.clone(),)*);
+                let ($($c,)*) = (self.f)(cloned, data);
+
+                $(*$r = $c;)*
+            }
+        }
+    };
+}
+
+all_tuples!(impl_effect_for_entity_components_with, 1, 15, C, c, r);

--- a/src/effects/entity_components.rs
+++ b/src/effects/entity_components.rs
@@ -118,7 +118,11 @@ mod tests {
     use proptest::sample::SizeRange;
 
     use super::*;
-    use crate::effects::number_data::NumberComponent;
+    use crate::effects::number_data::{
+        two_number_components_one_way_transform,
+        two_number_components_one_way_transform_with_void_query_data,
+        NumberComponent,
+    };
     use crate::effects::one_way_fn::OneWayFn;
     use crate::prelude::affect;
 
@@ -191,12 +195,7 @@ mod tests {
                 (move || {
                     EntityComponentsWith::<_, _, ()>::new(
                         entity_to_transform,
-                        move |(NumberComponent(n0), NumberComponent(n1)), _| {
-                            (
-                                NumberComponent::<0>(f0.call(n0)),
-                                NumberComponent::<1>(f1.call(n1)),
-                            )
-                        },
+                        two_number_components_one_way_transform_with_void_query_data(f0, f1)
                     )
                 })
                 .pipe(affect),
@@ -204,19 +203,16 @@ mod tests {
 
             app.update();
 
-            for ((NumberComponent(initial0), NumberComponent(initial1)), entity) in
+            for (initial, entity) in
                 initial_bundles.into_iter().zip(entities)
             {
                 let actual0 = app.world().get::<NumberComponent<0>>(entity).unwrap();
                 let actual1 = app.world().get::<NumberComponent<1>>(entity).unwrap();
 
                 let (expected0, expected1) = if entity == entity_to_transform {
-                    (
-                        NumberComponent(f0.call(initial0)),
-                        NumberComponent(f1.call(initial1)),
-                    )
+                    two_number_components_one_way_transform(f0, f1)(initial)
                 } else {
-                    (NumberComponent(initial0), NumberComponent(initial1))
+                    initial
                 };
 
                 prop_assert_eq!(actual0, &expected0);

--- a/src/effects/entity_components.rs
+++ b/src/effects/entity_components.rs
@@ -136,7 +136,7 @@ mod tests {
     proptest! {
         #[test]
         fn entity_components_put_overwrites_initial_state_of_single_entity(
-            (initial_bundles, index_to_put) in vec_and_index(any::<(NumberComponent<0>, NumberComponent<1>)>(), 1..16),
+            (initial_bundles, index_to_put) in vec_and_index(any::<(NumberComponent<0>, NumberComponent<1>)>(), 1..4),
             put: (NumberComponent<0>, NumberComponent<1>)
         ) {
             let mut app = App::new();

--- a/src/effects/entity_components.rs
+++ b/src/effects/entity_components.rs
@@ -10,6 +10,7 @@ use crate::Effect;
 /// [`Effect`] that sets the `Component`s of the provided entity to the provided `Component` tuple.
 ///
 /// If an entity with these components cannot be found, logs an error.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct EntityComponentsPut<C> {
     entity: Entity,
     components: C,
@@ -54,6 +55,7 @@ all_tuples!(impl_effect_for_entity_components_put, 1, 15, C, c, r);
 /// Can be parameterized by a `ReadOnlyQueryData` to access additional query data in the function.
 ///
 /// If an entity with these components cannot be found, logs an error.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct EntityComponentsWith<F, C, Data = ()>
 where
     F: for<'a> Fn(C, <Data as WorldQuery>::Item<'a>) -> C + Send + Sync,

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -12,6 +12,7 @@ mod components;
 pub use components::{ComponentsPut, ComponentsWith};
 
 mod entity_components;
+pub use entity_components::{EntityComponentsPut, EntityComponentsWith};
 
 #[cfg(test)]
 mod one_way_fn;

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -11,6 +11,8 @@ pub use event::EventSend;
 mod components;
 pub use components::{ComponentsPut, ComponentsWith};
 
+mod entity_components;
+
 #[cfg(test)]
 mod one_way_fn;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,13 @@
 //! `use bevy_pipe_affect::prelude::*;` to import common items.
 
-pub use crate::effects::{ComponentsPut, ComponentsWith, EventSend, ResPut, ResWith};
+pub use crate::effects::{
+    ComponentsPut,
+    ComponentsWith,
+    EntityComponentsPut,
+    EntityComponentsWith,
+    EventSend,
+    ResPut,
+    ResWith,
+};
 pub use crate::system_combinators::{affect, and_compose};
 pub use crate::{Effect, EffectOut};


### PR DESCRIPTION
One of the most important side effects of bevy systems is updating the state of components. Previously, `Components-` effects were added to apply a component state transition to all entities in a query. This change introduces two effects for definining state transitions of components for a single entity:
- `EntityComponentsPut` sets a provided entity's tuple of components to the provided values
- `EntityComponentsWith` transforms a provided entity's tuple of components with the provided function. This function can also be parameterized by some `ReadOnlyQueryData`.
