### PR TITLE
feat: add `CommandQueue` effect

### DIFF
--- a/mvp-effects.md
+++ b/mvp-effects.md
@@ -20,15 +20,15 @@
 - [x] `EntityComponentsWith`
 
 # Command Effects
-- [ ] `InsertResource`
-- [ ] `RemoveResource`
-- [ ] `CommandEffect<C>`
+- [x] `CommandQueue<C>`
+- [x] `CommandInsertResource`
+- [x] `CommandRemoveResource`
+- [x] `CommandSpawnEmptyAnd`
 
 # Entity command effects:
-- [ ] `SpawnThen`
-- [ ] `EntityInsert`
-- [ ] `EntityRemove`
-- [ ] `EntityDespawn`
+- [ ] `CommandEntityInsert`
+- [ ] `CommandEntityRemove`
+- [ ] `CommandEntityDespawnRecursive`
 
 *For MVP, `CommandEffect<C>` enables hierarchy commands*
 

--- a/mvp-effects.md
+++ b/mvp-effects.md
@@ -23,9 +23,9 @@
 - [x] `CommandQueue<C>`
 - [x] `CommandInsertResource`
 - [x] `CommandRemoveResource`
-- [x] `CommandSpawnEmptyAnd`
 
 # Entity command effects:
+- [ ] `CommandSpawnEmptyAnd`
 - [ ] `CommandEntityInsert`
 - [ ] `CommandEntityRemove`
 - [ ] `CommandEntityDespawnRecursive`

--- a/mvp-effects.md
+++ b/mvp-effects.md
@@ -21,8 +21,8 @@
 
 # Command Effects
 - [x] `CommandQueue<C>`
-- [x] `CommandInsertResource`
-- [x] `CommandRemoveResource`
+- [ ] `CommandInsertResource`
+- [ ] `CommandRemoveResource`
 
 # Entity command effects:
 - [ ] `CommandSpawnEmptyAnd`

--- a/src/effects/command.rs
+++ b/src/effects/command.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 use crate::Effect;
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub struct CommandQueue<C>(C)
+pub struct CommandQueue<C>(pub C)
 where
     C: Command;
 
@@ -21,7 +21,7 @@ where
 }
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub struct CommandInsertResource<R>(R)
+pub struct CommandInsertResource<R>(pub R)
 where
     R: Resource;
 
@@ -48,7 +48,8 @@ impl<R> CommandRemoveResource<R>
 where
     R: Resource,
 {
-    fn new() -> Self {
+    /// Construct a new [`CommandRemoveResource`]
+    pub fn new() -> Self {
         CommandRemoveResource {
             resource: PhantomData,
         }
@@ -67,7 +68,7 @@ where
 }
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub struct CommandSpawnEmptyAnd<F, E>(F)
+pub struct CommandSpawnEmptyAnd<F, E>(pub F)
 where
     F: FnOnce(Entity) -> E,
     E: Effect;

--- a/src/effects/command.rs
+++ b/src/effects/command.rs
@@ -1,5 +1,3 @@
-use std::marker::PhantomData;
-
 use bevy::prelude::*;
 
 use crate::Effect;
@@ -19,57 +17,6 @@ where
 
     fn affect(self, param: &mut <Self::MutParam as bevy::ecs::system::SystemParam>::Item<'_, '_>) {
         param.queue(self.0)
-    }
-}
-
-/// [`Effect`] that queues a command for inserting the provided `Resource` in the `World`.
-#[doc = include_str!("defer_command_note.md")]
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub struct CommandInsertResource<R>(pub R)
-where
-    R: Resource;
-
-impl<R> Effect for CommandInsertResource<R>
-where
-    R: Resource,
-{
-    type MutParam = Commands<'static, 'static>;
-
-    fn affect(self, param: &mut <Self::MutParam as bevy::ecs::system::SystemParam>::Item<'_, '_>) {
-        param.insert_resource(self.0);
-    }
-}
-
-/// [`Effect`] that queues a command for removing a `Resource` from the `World`.
-#[doc = include_str!("defer_command_note.md")]
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub struct CommandRemoveResource<R>
-where
-    R: Resource,
-{
-    resource: PhantomData<R>,
-}
-
-impl<R> CommandRemoveResource<R>
-where
-    R: Resource,
-{
-    /// Construct a new [`CommandRemoveResource`]
-    pub fn new() -> Self {
-        CommandRemoveResource {
-            resource: PhantomData,
-        }
-    }
-}
-
-impl<R> Effect for CommandRemoveResource<R>
-where
-    R: Resource,
-{
-    type MutParam = Commands<'static, 'static>;
-
-    fn affect(self, param: &mut <Self::MutParam as bevy::ecs::system::SystemParam>::Item<'_, '_>) {
-        param.remove_resource::<R>();
     }
 }
 

--- a/src/effects/command.rs
+++ b/src/effects/command.rs
@@ -72,25 +72,3 @@ where
         param.remove_resource::<R>();
     }
 }
-
-/// [`Effect`] that reserves a new empty `Entity` to be spawned, and inputs it to the provided
-/// function to cause another effect.
-#[doc = include_str!("defer_command_note.md")]
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub struct CommandSpawnEmptyAnd<F, E>(pub F)
-where
-    F: FnOnce(Entity) -> E,
-    E: Effect;
-
-impl<F, E> Effect for CommandSpawnEmptyAnd<F, E>
-where
-    F: FnOnce(Entity) -> E,
-    E: Effect,
-{
-    type MutParam = ParamSet<'static, 'static, (Commands<'static, 'static>, E::MutParam)>;
-
-    fn affect(self, param: &mut <Self::MutParam as bevy::ecs::system::SystemParam>::Item<'_, '_>) {
-        let entity = param.p0().spawn_empty().id();
-        (self.0)(entity).affect(&mut param.p1());
-    }
-}

--- a/src/effects/command.rs
+++ b/src/effects/command.rs
@@ -4,6 +4,8 @@ use bevy::prelude::*;
 
 use crate::Effect;
 
+/// [`Effect`] that pushes a generic command to the command queue.
+#[doc = include_str!("defer_command_note.md")]
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub struct CommandQueue<C>(pub C)
 where
@@ -20,6 +22,8 @@ where
     }
 }
 
+/// [`Effect`] that queues a command for inserting the provided `Resource` in the `World`.
+#[doc = include_str!("defer_command_note.md")]
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub struct CommandInsertResource<R>(pub R)
 where
@@ -36,6 +40,8 @@ where
     }
 }
 
+/// [`Effect`] that queues a command for removing a `Resource` from the `World`.
+#[doc = include_str!("defer_command_note.md")]
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub struct CommandRemoveResource<R>
 where
@@ -67,6 +73,9 @@ where
     }
 }
 
+/// [`Effect`] that reserves a new empty `Entity` to be spawned, and inputs it to the provided
+/// function to cause another effect.
+#[doc = include_str!("defer_command_note.md")]
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub struct CommandSpawnEmptyAnd<F, E>(pub F)
 where

--- a/src/effects/command.rs
+++ b/src/effects/command.rs
@@ -1,0 +1,86 @@
+use std::marker::PhantomData;
+
+use bevy::prelude::*;
+
+use crate::Effect;
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct CommandQueue<C>(C)
+where
+    C: Command;
+
+impl<C> Effect for CommandQueue<C>
+where
+    C: Command,
+{
+    type MutParam = Commands<'static, 'static>;
+
+    fn affect(self, param: &mut <Self::MutParam as bevy::ecs::system::SystemParam>::Item<'_, '_>) {
+        param.queue(self.0)
+    }
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct CommandInsertResource<R>(R)
+where
+    R: Resource;
+
+impl<R> Effect for CommandInsertResource<R>
+where
+    R: Resource,
+{
+    type MutParam = Commands<'static, 'static>;
+
+    fn affect(self, param: &mut <Self::MutParam as bevy::ecs::system::SystemParam>::Item<'_, '_>) {
+        param.insert_resource(self.0);
+    }
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct CommandRemoveResource<R>
+where
+    R: Resource,
+{
+    resource: PhantomData<R>,
+}
+
+impl<R> CommandRemoveResource<R>
+where
+    R: Resource,
+{
+    fn new() -> Self {
+        CommandRemoveResource {
+            resource: PhantomData,
+        }
+    }
+}
+
+impl<R> Effect for CommandRemoveResource<R>
+where
+    R: Resource,
+{
+    type MutParam = Commands<'static, 'static>;
+
+    fn affect(self, param: &mut <Self::MutParam as bevy::ecs::system::SystemParam>::Item<'_, '_>) {
+        param.remove_resource::<R>();
+    }
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct CommandSpawnEmptyAnd<F, E>(F)
+where
+    F: FnOnce(Entity) -> E,
+    E: Effect;
+
+impl<F, E> Effect for CommandSpawnEmptyAnd<F, E>
+where
+    F: FnOnce(Entity) -> E,
+    E: Effect,
+{
+    type MutParam = ParamSet<'static, 'static, (Commands<'static, 'static>, E::MutParam)>;
+
+    fn affect(self, param: &mut <Self::MutParam as bevy::ecs::system::SystemParam>::Item<'_, '_>) {
+        let entity = param.p0().spawn_empty().id();
+        (self.0)(entity).affect(&mut param.p1());
+    }
+}

--- a/src/effects/defer_command_note.md
+++ b/src/effects/defer_command_note.md
@@ -1,0 +1,3 @@
+ 
+ *Note: `Command` effects only affect the command queue.
+ The `World` modifications of the command only take place when the `apply_deferred` system runs.*

--- a/src/effects/entity_components.rs
+++ b/src/effects/entity_components.rs
@@ -59,7 +59,7 @@ all_tuples!(impl_effect_for_entity_components_put, 1, 15, C, c, r);
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct EntityComponentsWith<F, C, Data = ()>
 where
-    F: for<'a> Fn(C, <Data as QueryData>::Item<'a>) -> C + Send + Sync,
+    F: for<'a> FnOnce(C, <Data as QueryData>::Item<'a>) -> C + Send + Sync,
     C: Clone,
     Data: ReadOnlyQueryData,
 {
@@ -71,7 +71,7 @@ where
 
 impl<F, C, Data> EntityComponentsWith<F, C, Data>
 where
-    F: for<'a> Fn(C, <Data as QueryData>::Item<'a>) -> C + Send + Sync,
+    F: for<'a> FnOnce(C, <Data as QueryData>::Item<'a>) -> C + Send + Sync,
     C: Clone,
     Data: ReadOnlyQueryData,
 {
@@ -90,7 +90,7 @@ macro_rules! impl_effect_for_entity_components_with {
     ($(($C:ident, $c:ident, $r:ident)),*) => {
         impl<F, $($C,)* Data> Effect for EntityComponentsWith<F, ($($C,)*), Data>
         where
-            F: for<'a> Fn(($($C,)*), <Data as QueryData>::Item<'a>) -> ($($C,)*) + Send + Sync,
+            F: for<'a> FnOnce(($($C,)*), <Data as QueryData>::Item<'a>) -> ($($C,)*) + Send + Sync,
             $($C: Component<Mutability = Mutable> + Clone,)*
             Data: ReadOnlyQueryData + 'static,
         {

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -15,6 +15,12 @@ mod entity_components;
 pub use entity_components::{EntityComponentsPut, EntityComponentsWith};
 
 mod command;
+pub use command::{
+    CommandInsertResource,
+    CommandQueue,
+    CommandRemoveResource,
+    CommandSpawnEmptyAnd,
+};
 
 #[cfg(test)]
 mod one_way_fn;

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -15,7 +15,7 @@ mod entity_components;
 pub use entity_components::{EntityComponentsPut, EntityComponentsWith};
 
 mod command;
-pub use command::{CommandInsertResource, CommandQueue, CommandRemoveResource};
+pub use command::CommandQueue;
 
 #[cfg(test)]
 mod one_way_fn;

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -14,6 +14,8 @@ pub use components::{ComponentsPut, ComponentsWith};
 mod entity_components;
 pub use entity_components::{EntityComponentsPut, EntityComponentsWith};
 
+mod command;
+
 #[cfg(test)]
 mod one_way_fn;
 

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -15,12 +15,7 @@ mod entity_components;
 pub use entity_components::{EntityComponentsPut, EntityComponentsWith};
 
 mod command;
-pub use command::{
-    CommandInsertResource,
-    CommandQueue,
-    CommandRemoveResource,
-    CommandSpawnEmptyAnd,
-};
+pub use command::{CommandInsertResource, CommandQueue, CommandRemoveResource};
 
 #[cfg(test)]
 mod one_way_fn;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,9 +1,7 @@
 //! `use bevy_pipe_affect::prelude::*;` to import common items.
 
 pub use crate::effects::{
-    CommandInsertResource,
     CommandQueue,
-    CommandRemoveResource,
     ComponentsPut,
     ComponentsWith,
     EntityComponentsPut,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -4,7 +4,6 @@ pub use crate::effects::{
     CommandInsertResource,
     CommandQueue,
     CommandRemoveResource,
-    CommandSpawnEmptyAnd,
     ComponentsPut,
     ComponentsWith,
     EntityComponentsPut,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,6 +1,10 @@
 //! `use bevy_pipe_affect::prelude::*;` to import common items.
 
 pub use crate::effects::{
+    CommandInsertResource,
+    CommandQueue,
+    CommandRemoveResource,
+    CommandSpawnEmptyAnd,
     ComponentsPut,
     ComponentsWith,
     EntityComponentsPut,


### PR DESCRIPTION
The most generic and basic command effect `CommandQueue` is required for mvp. This allows for queuing up any world modification in a non-exclusive system to be later applied in the `apply_deferred` bevy system.
