### PR TITLE
feat: add `-Resource` related `Command` effects

### DIFF
--- a/mvp-effects.md
+++ b/mvp-effects.md
@@ -21,8 +21,8 @@
 
 # Command Effects
 - [x] `CommandQueue<C>`
-- [ ] `CommandInsertResource`
-- [ ] `CommandRemoveResource`
+- [x] `CommandInsertResource`
+- [x] `CommandRemoveResource`
 
 # Entity command effects:
 - [ ] `CommandSpawnEmptyAnd`

--- a/src/effects/command.rs
+++ b/src/effects/command.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use bevy::prelude::*;
 
 use crate::Effect;
@@ -17,6 +19,57 @@ where
 
     fn affect(self, param: &mut <Self::MutParam as bevy::ecs::system::SystemParam>::Item<'_, '_>) {
         param.queue(self.0)
+    }
+}
+
+/// [`Effect`] that queues a command for inserting the provided `Resource` in the `World`.
+#[doc = include_str!("defer_command_note.md")]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct CommandInsertResource<R>(pub R)
+where
+    R: Resource;
+
+impl<R> Effect for CommandInsertResource<R>
+where
+    R: Resource,
+{
+    type MutParam = Commands<'static, 'static>;
+
+    fn affect(self, param: &mut <Self::MutParam as bevy::ecs::system::SystemParam>::Item<'_, '_>) {
+        param.insert_resource(self.0);
+    }
+}
+
+/// [`Effect`] that queues a command for removing a `Resource` from the `World`.
+#[doc = include_str!("defer_command_note.md")]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct CommandRemoveResource<R>
+where
+    R: Resource,
+{
+    resource: PhantomData<R>,
+}
+
+impl<R> CommandRemoveResource<R>
+where
+    R: Resource,
+{
+    /// Construct a new [`CommandRemoveResource`]
+    pub fn new() -> Self {
+        CommandRemoveResource {
+            resource: PhantomData,
+        }
+    }
+}
+
+impl<R> Effect for CommandRemoveResource<R>
+where
+    R: Resource,
+{
+    type MutParam = Commands<'static, 'static>;
+
+    fn affect(self, param: &mut <Self::MutParam as bevy::ecs::system::SystemParam>::Item<'_, '_>) {
+        param.remove_resource::<R>();
     }
 }
 

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -15,7 +15,7 @@ mod entity_components;
 pub use entity_components::{EntityComponentsPut, EntityComponentsWith};
 
 mod command;
-pub use command::CommandQueue;
+pub use command::{CommandInsertResource, CommandQueue, CommandRemoveResource};
 
 #[cfg(test)]
 mod one_way_fn;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,7 +1,9 @@
 //! `use bevy_pipe_affect::prelude::*;` to import common items.
 
 pub use crate::effects::{
+    CommandInsertResource,
     CommandQueue,
+    CommandRemoveResource,
     ComponentsPut,
     ComponentsWith,
     EntityComponentsPut,


### PR DESCRIPTION
While the existing resource commands allow for resource modification, they don't allow for resource insertion/removal. This is typically done with commands, and deferred to the exclusive `apply_deferred` system. This adds `CommandInsertResource` and `CommandRemoveResource` accordingly.
