### PR TITLE
docs: adjust mvp effects for bevy 0.16 design considerations

### DIFF
--- a/mvp-effects.md
+++ b/mvp-effects.md
@@ -21,16 +21,49 @@
 
 # Command Effects
 - [x] `CommandQueue<C>`
+
 - [x] `CommandInsertResource`
 - [x] `CommandRemoveResource`
 
-# Entity command effects:
-- [ ] `CommandSpawnEmptyAnd`
-- [ ] `CommandEntityInsert`
-- [ ] `CommandEntityRemove`
-- [ ] `CommandEntityDespawnRecursive`
+- [ ] `CommandSpawnAnd`
 
-*For MVP, `CommandEffect<C>` enables hierarchy commands*
+## Nice to have
+- [ ] `CommandSpawnBatch`
+- [ ] `CommandInsertBatch`
+
+- [ ] `CommandRunSystem`
+- [ ] `CommandRunSystemWith`
+- [ ] `CommandRegisterSystemAnd`
+- [ ] `CommandUnregisterSystemAnd`
+
+- [ ] `CommandTrigger`
+- [ ] `CommandTriggerTargets`
+- [ ] `CommandAddObserverAnd`
+
+- [ ] `CommandRunSchedule`
+
+# Entity command effects:
+- [ ] `EntityCommandQueue<C>`
+
+- [ ] `EntityCommandInsert`
+- [ ] `EntityCommandRemove`
+- [ ] `EntityCommandDespawn`
+
+## Nice to have
+- [ ] `EntityCommandRetain`
+- [ ] `EntityCommandClear`
+
+- [ ] `EntityCommandObserve`
+- [ ] `EntityCommandTrigger`
+
+- [ ] `EntityCommandSetParentInPlace`
+- [ ] `EntityCommandRemoveParentInPlace`
+
+- [ ] `EntityCommandInsertRecursive`
+- [ ] `EntityCommandRemoveRecursive`
+
+*Most relationship/target commands have feature parity with plain insertions
+and removals on the relationship entity, so they don't have effects for mvp*
 
 # Tuple effects
 - [x] `(E0, E1, ... En)`
@@ -39,7 +72,8 @@
 - [ ] `IterEffect`
 - [ ] `Vec<E>`
 - [ ] `Option<E>`
+- [ ] `Either<E0, E1>`
 
 # Result Effects
-- [ ] `OrLog(Result<E, Error>, LogLevel)`
-- [ ] `Result<E, Error> = OrLog(..., LogLevel::Error)`
+- [ ] `ResultWithHandler(Result<E, Er>, Fn(BevyError, ErrorContext))`
+- [ ] `Result<E, Er>` *uses global error handler, or panics if unavailable, just like vanilla bevy*


### PR DESCRIPTION
Some modern features of bevy need to be accounted for in the effects mvp. Some of these may be older than bevy 0.16, but I was not familiar with all of them as the last bevy version I had intense contact with was 0.12-ish.

In particular, running systems with commands, observers, relations, and error handling are all pretty new. These are now accounted for in the mvp checklist, with some things merely being "nice to have".

`Either` has been tossed in here as well, which should have probably been included in the first place.