### PR TITLE
refactor: move effect impl on tuples to its own module

### DIFF
--- a/src/effect.rs
+++ b/src/effect.rs
@@ -1,6 +1,4 @@
 use bevy::ecs::system::SystemParam;
-use bevy::prelude::*;
-use variadics_please::all_tuples;
 
 /// Define a state transition in `bevy`'s ECS.
 ///
@@ -14,19 +12,3 @@ pub trait Effect {
     /// Perform the state transition on the parameter.
     fn affect(self, param: &mut <Self::MutParam as SystemParam>::Item<'_, '_>);
 }
-
-macro_rules! impl_effect {
-    ($(($E:ident, $e:ident, $p:ident)),*) => {
-        impl<$($E),*> Effect for ($($E,)*)
-        where $($E: Effect,)* {
-            type MutParam = ParamSet<'static, 'static, ($(<$E as Effect>::MutParam,)*)>;
-
-            fn affect(self, param: &mut <Self::MutParam as SystemParam>::Item<'_, '_>) {
-                let ($($e,)*) = self;
-                $($e.affect(&mut param.$p());)*
-            }
-        }
-    };
-}
-
-all_tuples!(impl_effect, 1, 8, E, e, p);

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -17,6 +17,8 @@ pub use entity_components::{EntityComponentsPut, EntityComponentsWith};
 mod command;
 pub use command::{CommandInsertResource, CommandQueue, CommandRemoveResource};
 
+mod variadic;
+
 #[cfg(test)]
 mod one_way_fn;
 

--- a/src/effects/variadic.rs
+++ b/src/effects/variadic.rs
@@ -1,0 +1,23 @@
+//! Implements [`Effect`] for tuples of effects up to size 8.
+
+use bevy::ecs::system::SystemParam;
+use bevy::prelude::*;
+use variadics_please::all_tuples;
+
+use crate::Effect;
+
+macro_rules! impl_effect {
+    ($(($E:ident, $e:ident, $p:ident)),*) => {
+        impl<$($E),*> Effect for ($($E,)*)
+        where $($E: Effect,)* {
+            type MutParam = ParamSet<'static, 'static, ($(<$E as Effect>::MutParam,)*)>;
+
+            fn affect(self, param: &mut <Self::MutParam as SystemParam>::Item<'_, '_>) {
+                let ($($e,)*) = self;
+                $($e.affect(&mut param.$p());)*
+            }
+        }
+    };
+}
+
+all_tuples!(impl_effect, 1, 8, E, e, p);


### PR DESCRIPTION
The implementation of `Effect` for tuples is currently in the same module as the `Effect` definition. This breaks the current code organization patterns. This change moves it to its own module accordingly.
