### PR TITLE
feat: implement `Effect` for unit type `()`

### DIFF
--- a/mvp-effects.md
+++ b/mvp-effects.md
@@ -65,8 +65,9 @@
 *Most relationship/target commands have feature parity with plain insertions
 and removals on the relationship entity, so they don't have effects for mvp*
 
-# Tuple effects
+# Variadic effects
 - [x] `(E0, E1, ... En)`
+- [x] `()`
 
 # Iterator Effects
 - [ ] `IterEffect`

--- a/src/effects/variadic.rs
+++ b/src/effects/variadic.rs
@@ -21,3 +21,9 @@ macro_rules! impl_effect {
 }
 
 all_tuples!(impl_effect, 1, 8, E, e, p);
+
+impl Effect for () {
+    type MutParam = ();
+
+    fn affect(self, _: &mut <Self::MutParam as SystemParam>::Item<'_, '_>) {}
+}


### PR DESCRIPTION
For composability of effects, it is important to cover trivial cases. The current variadic support does cover the trivial case of a single-element tuple `(E,)`, but not the 0-element unit type `()`. This change provides that support.
