### PR TITLE
feat: add `CommandSpawnAnd` effect

### DIFF
--- a/mvp-effects.md
+++ b/mvp-effects.md
@@ -25,7 +25,7 @@
 - [x] `CommandInsertResource`
 - [x] `CommandRemoveResource`
 
-- [ ] `CommandSpawnAnd`
+- [x] `CommandSpawnAnd`
 
 ## Nice to have
 - [ ] `CommandSpawnBatch`

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -15,7 +15,7 @@ mod entity_components;
 pub use entity_components::{EntityComponentsPut, EntityComponentsWith};
 
 mod command;
-pub use command::{CommandInsertResource, CommandQueue, CommandRemoveResource};
+pub use command::{CommandInsertResource, CommandQueue, CommandRemoveResource, CommandSpawnAnd};
 
 mod entity_command;
 pub use entity_command::{EntityCommandInsert, EntityCommandQueue, EntityCommandRemove};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -4,6 +4,7 @@ pub use crate::effects::{
     CommandInsertResource,
     CommandQueue,
     CommandRemoveResource,
+    CommandSpawnAnd,
     ComponentsPut,
     ComponentsWith,
     EntityCommandInsert,


### PR DESCRIPTION
One of the most basic ECS operations is the spawning of entities. This is usually done with `Commands::spawn`, which queues up an entity to be spawned with a provided set of components the next time the bevy `apply_deferred` system is run.

However, it is common to use the resulting `Entity` id to cause more effects, like creating relationships (especially hierarchies), storing special entities in resources, or writing events regarding them. An effect spawning an entity would not have access to its id on creation, since it is spawned later during the `affect` system.

This change adds the `CommandSpawnAnd` resource. It can spawn entities with bundles, but it can also cause more effects with the resulting `Entity` by accepting closures like `|Entity| -> impl Effect`.
