### PR TITLE
feat: add `EntityCommandDespawn` effect

### DIFF
--- a/mvp-effects.md
+++ b/mvp-effects.md
@@ -47,7 +47,7 @@
 
 - [x] `EntityCommandInsert`
 - [x] `EntityCommandRemove`
-- [ ] `EntityCommandDespawn`
+- [x] `EntityCommandDespawn`
 
 ## Nice to have
 - [ ] `EntityCommandRetain`

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -18,7 +18,12 @@ mod command;
 pub use command::{CommandInsertResource, CommandQueue, CommandRemoveResource, CommandSpawnAnd};
 
 mod entity_command;
-pub use entity_command::{EntityCommandInsert, EntityCommandQueue, EntityCommandRemove};
+pub use entity_command::{
+    EntityCommandDespawn,
+    EntityCommandInsert,
+    EntityCommandQueue,
+    EntityCommandRemove,
+};
 
 mod variadic;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -7,6 +7,7 @@ pub use crate::effects::{
     CommandSpawnAnd,
     ComponentsPut,
     ComponentsWith,
+    EntityCommandDespawn,
     EntityCommandInsert,
     EntityCommandQueue,
     EntityCommandRemove,


### PR DESCRIPTION
We can now spawn entities, insert components on them, and remove components on them. We still need to be able to despawn entities to meet the MVP. This change adds the `EntityCommandDespawn` effect to that end.
