### PR TITLE
feat: implement `Effect` for `Either`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,6 +905,7 @@ version = "0.1.0"
 dependencies = [
  "bevy",
  "blake2",
+ "either",
  "proptest",
  "proptest-derive",
  "variadics_please",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 bevy = "0.16.1"
 variadics_please = "1.1.0"
+either = "1.13.0"
 
 [dev-dependencies]
 proptest = "1.7.0"

--- a/mvp-effects.md
+++ b/mvp-effects.md
@@ -68,7 +68,7 @@ and removals on the relationship entity, so they don't have effects for mvp*
 # Algebra effects
 - [x] `(E0, E1, ... En)`
 - [x] `()`
-- [ ] `Either<E0, E1>`
+- [x] `Either<E0, E1>`
 
 # Iterator Effects
 - [ ] `IterEffect`

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,7 @@
 //! `use bevy_pipe_affect::prelude::*;` to import common items.
 
+pub use either::Either;
+
 pub use crate::effects::{
     CommandInsertResource,
     CommandQueue,


### PR DESCRIPTION
`Effect` is implemented for tuples, which provides a general-purpose product type of effects. To complete the effect "algebra", we also need a sum-type. The most basic general-purpose sum-type in the rust ecosystem would be `Either`, which this change provides an implementation for.
