### PR TITLE
feat: add `IterEffect` effect and add `Vec` and `Option` implementations

### DIFF
--- a/mvp-effects.md
+++ b/mvp-effects.md
@@ -71,9 +71,9 @@ and removals on the relationship entity, so they don't have effects for mvp*
 - [x] `Either<E0, E1>`
 
 # Iterator Effects
-- [ ] `IterEffect`
-- [ ] `Vec<E>`
-- [ ] `Option<E>`
+- [x] `IterEffect`
+- [x] `Vec<E>`
+- [x] `Option<E>`
 
 # Result Effects
 - [ ] `ResultWithHandler(Result<E, Er>, Fn(BevyError, ErrorContext))`

--- a/src/effects/iter.rs
+++ b/src/effects/iter.rs
@@ -1,0 +1,138 @@
+use crate::Effect;
+
+/// [`Effect`] that causes an effect for each item in the iterator.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
+pub struct IterEffect<I>(pub I)
+where
+    I: IntoIterator,
+    I::Item: Effect;
+
+impl<I> Effect for IterEffect<I>
+where
+    I: IntoIterator,
+    I::Item: Effect,
+{
+    type MutParam = <I::Item as Effect>::MutParam;
+
+    fn affect(self, param: &mut <Self::MutParam as bevy::ecs::system::SystemParam>::Item<'_, '_>) {
+        self.0.into_iter().for_each(|e| {
+            e.affect(param);
+        });
+    }
+}
+
+impl<E> Effect for Vec<E>
+where
+    E: Effect,
+{
+    type MutParam = E::MutParam;
+
+    fn affect(self, param: &mut <Self::MutParam as bevy::ecs::system::SystemParam>::Item<'_, '_>) {
+        IterEffect(self).affect(param);
+    }
+}
+
+impl<E> Effect for Option<E>
+where
+    E: Effect,
+{
+    type MutParam = E::MutParam;
+
+    fn affect(self, param: &mut <Self::MutParam as bevy::ecs::system::SystemParam>::Item<'_, '_>) {
+        IterEffect(self).affect(param);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use bevy::prelude::*;
+    use proptest::prelude::*;
+
+    use crate::effects::number_data::NumberComponent;
+    use crate::effects::{CommandSpawnAnd, EventWrite, ResPut};
+    use crate::prelude::affect;
+
+    proptest! {
+        #[test]
+        fn vecs_can_spawn_many_entities(mut components in proptest::collection::vec(any::<NumberComponent<0>>(), 1..64)) {
+            let mut app = App::new();
+
+            let components_clone = components.clone();
+            app.add_systems(Update, (move || components_clone.clone().into_iter().map(|c| CommandSpawnAnd(c, |_| ())).collect::<Vec<_>>()).pipe(affect));
+
+            app.update();
+
+            for num in app.world_mut().query::<&NumberComponent<0>>().iter(app.world()) {
+                let index = components.iter().position(|c| c == num).unwrap();
+                components.remove(index);
+            }
+
+            assert!(components.is_empty())
+        }
+    }
+
+    #[test]
+    fn option_can_sometimes_cause_effect() {
+        #[derive(Event)]
+        struct UpdateIsEven;
+
+        #[derive(Resource)]
+        struct NumUpdates(usize);
+
+        let mut app = App::new();
+
+        app.add_event::<UpdateIsEven>()
+            .insert_resource(NumUpdates(0))
+            .add_systems(
+                Update,
+                (|num_updates: Res<NumUpdates>| {
+                    (
+                        ResPut(NumUpdates(num_updates.0 + 1)),
+                        (num_updates.0 % 2 == 0).then_some(EventWrite(UpdateIsEven)),
+                    )
+                })
+                .pipe(affect),
+            );
+
+        app.update();
+
+        assert_eq!(
+            app.world()
+                .resource::<Events<UpdateIsEven>>()
+                .iter_current_update_events()
+                .count(),
+            1
+        );
+
+        app.update();
+
+        assert_eq!(
+            app.world()
+                .resource::<Events<UpdateIsEven>>()
+                .iter_current_update_events()
+                .count(),
+            0
+        );
+
+        app.update();
+
+        assert_eq!(
+            app.world()
+                .resource::<Events<UpdateIsEven>>()
+                .iter_current_update_events()
+                .count(),
+            1
+        );
+
+        app.update();
+
+        assert_eq!(
+            app.world()
+                .resource::<Events<UpdateIsEven>>()
+                .iter_current_update_events()
+                .count(),
+            0
+        );
+    }
+}

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -27,6 +27,9 @@ pub use entity_command::{
 
 mod algebra;
 
+mod iter;
+pub use iter::IterEffect;
+
 #[cfg(test)]
 mod one_way_fn;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -16,6 +16,7 @@ pub use crate::effects::{
     EntityComponentsPut,
     EntityComponentsWith,
     EventWrite,
+    IterEffect,
     ResPut,
     ResWith,
 };


### PR DESCRIPTION
There are times when you need to produce an effect a variable number of times, or sometimes not at all. These situations are analogous to the `Vec` and `Option` types, or more generally, iterators. This change adds an `IterEffect` for generic iterators of effects, as well as implementations for `Vec` and `Option`.
