### PR TITLE
bevy_pipe_affect]$ git commit -m "feat: add `AffectOrHandle` effect and `Result` implementation

### DIFF
--- a/mvp-effects.md
+++ b/mvp-effects.md
@@ -76,5 +76,5 @@ and removals on the relationship entity, so they don't have effects for mvp*
 - [x] `Option<E>`
 
 # Result Effects
-- [ ] `ResultWithHandler(Result<E, Er>, Fn(BevyError, ErrorContext))`
-- [ ] `Result<E, Er>` *uses global error handler, or panics if unavailable, just like vanilla bevy*
+- [x] `AffectOrHandle(Result<E, Er>, Fn(BevyError, ErrorContext))`
+- [x] `Result<E, Er>` *uses global error handler, or panics if unavailable, just like vanilla bevy*

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -30,6 +30,9 @@ mod algebra;
 mod iter;
 pub use iter::IterEffect;
 
+mod error;
+pub use error::AffectOrHandle;
+
 #[cfg(test)]
 mod one_way_fn;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -3,6 +3,7 @@
 pub use either::Either;
 
 pub use crate::effects::{
+    AffectOrHandle,
     CommandInsertResource,
     CommandQueue,
     CommandRemoveResource,


### PR DESCRIPTION
The final important building block of effects is the `Result` effect. Having this effect will be quite powerful, not only allowing users to produce errors, but also partial failures if they desire (by using a result in a nesting of effects). This change implements it with the help of a new `AffectOrHandle` effect.
