### PR TITLE
refactor: rename IterEffect to AffectMany

### DIFF
--- a/mvp-effects.md
+++ b/mvp-effects.md
@@ -71,7 +71,7 @@ and removals on the relationship entity, so they don't have effects for mvp*
 - [x] `Either<E0, E1>`
 
 # Iterator Effects
-- [x] `IterEffect`
+- [x] `AffectMany`
 - [x] `Vec<E>`
 - [x] `Option<E>`
 

--- a/src/effects/iter.rs
+++ b/src/effects/iter.rs
@@ -1,13 +1,15 @@
 use crate::Effect;
 
-/// [`Effect`] that causes an effect for each item in the iterator.
+/// [`Effect`] that causes all effects in the provided iterator.
+///
+/// Using a plain `Vec` or `Option` as an effect works too.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
-pub struct IterEffect<I>(pub I)
+pub struct AffectMany<I>(pub I)
 where
     I: IntoIterator,
     I::Item: Effect;
 
-impl<I> Effect for IterEffect<I>
+impl<I> Effect for AffectMany<I>
 where
     I: IntoIterator,
     I::Item: Effect,
@@ -28,7 +30,7 @@ where
     type MutParam = E::MutParam;
 
     fn affect(self, param: &mut <Self::MutParam as bevy::ecs::system::SystemParam>::Item<'_, '_>) {
-        IterEffect(self).affect(param);
+        AffectMany(self).affect(param);
     }
 }
 
@@ -39,7 +41,7 @@ where
     type MutParam = E::MutParam;
 
     fn affect(self, param: &mut <Self::MutParam as bevy::ecs::system::SystemParam>::Item<'_, '_>) {
-        IterEffect(self).affect(param);
+        AffectMany(self).affect(param);
     }
 }
 

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -28,7 +28,7 @@ pub use entity_command::{
 mod algebra;
 
 mod iter;
-pub use iter::IterEffect;
+pub use iter::AffectMany;
 
 mod error;
 pub use error::AffectOrHandle;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -3,6 +3,7 @@
 pub use either::Either;
 
 pub use crate::effects::{
+    AffectMany,
     AffectOrHandle,
     CommandInsertResource,
     CommandQueue,
@@ -17,7 +18,6 @@ pub use crate::effects::{
     EntityComponentsPut,
     EntityComponentsWith,
     EventWrite,
-    IterEffect,
     ResPut,
     ResWith,
 };


### PR DESCRIPTION
The trend with all the effects so far is to use verbs in their names. IterEffect is an exception to this. This renames IterEffect to AffectMany accordingly.
