### PR TITLE
 refactor: rename Put effects to Set, and With effects to SetWith

### DIFF
--- a/examples/rainbow-clear-color.rs
+++ b/examples/rainbow-clear-color.rs
@@ -21,7 +21,7 @@ fn sample_system_with_effect_and_input(
     In(theta): In<f32>,
     current: Res<ClearColor>,
 ) -> impl Effect {
-    ResPut(ClearColor(current.0.rotate_hue(theta)))
+    ResSet(ClearColor(current.0.rotate_hue(theta)))
 }
 
 #[derive(Resource, Default)]
@@ -29,9 +29,9 @@ struct NumUpdates(u32);
 
 fn sample_system_with_effect_and_output(
     num_updates: Res<NumUpdates>,
-) -> EffectOut<ResPut<NumUpdates>, f32> {
+) -> EffectOut<ResSet<NumUpdates>, f32> {
     EffectOut(
-        ResPut(NumUpdates(num_updates.0 + 1)),
+        ResSet(NumUpdates(num_updates.0 + 1)),
         (num_updates.0 % 10) as f32 / 10.,
     )
 }

--- a/mvp-effects.md
+++ b/mvp-effects.md
@@ -1,10 +1,10 @@
 # Resource Effects
-- [x] `ResPut`
-- [x] `ResWith`
+- [x] `ResSet`
+- [x] `ResSetWith`
 
 # Local?
-- [ ] `LocalPut`?
-- [ ] `LocalWith`?
+- [ ] `LocalSet`?
+- [ ] `LocalSetWith`?
 
 *Need to research.. Could lead to confusing experience about which system the parameter is local to.*
 
@@ -12,12 +12,12 @@
 - [x] `EventWrite`
 
 # Components Effects
-- [x] `ComponentsPut`
-- [x] `ComponentsWith`
+- [x] `ComponentsSet`
+- [x] `ComponentsSetWith`
 
 # EntityComponents Effects
-- [x] `EntityComponentsPut`
-- [x] `EntityComponentsWith`
+- [x] `EntityComponentsSet`
+- [x] `EntityComponentsSetWith`
 
 # Command Effects
 - [x] `CommandQueue<C>`

--- a/src/effects/algebra.rs
+++ b/src/effects/algebra.rs
@@ -50,7 +50,7 @@ mod tests {
 
     use super::*;
     use crate::effects::number_data::NumberResource;
-    use crate::effects::ResPut;
+    use crate::effects::ResSet;
     use crate::prelude::affect;
 
     proptest! {
@@ -61,9 +61,9 @@ mod tests {
             app.insert_resource(NumberResource(current_value)).add_systems(
                 Update,
                 (|num: Res<NumberResource>| if num.0 % 2 == 0 {
-                    Either::Left(ResPut(NumberResource(num.0 / 2)))
+                    Either::Left(ResSet(NumberResource(num.0 / 2)))
                 } else {
-                    Either::Right(ResPut(NumberResource(3 * num.0 + 1)))
+                    Either::Right(ResSet(NumberResource(3 * num.0 + 1)))
                 })
                 .pipe(affect),
             );

--- a/src/effects/error.rs
+++ b/src/effects/error.rs
@@ -18,7 +18,7 @@ use crate::Effect;
 ///     let result = match clear_color.0 {
 ///         Color::Srgba(srgba) => {
 ///             let color = Color::Srgba(Srgba { red: 0., ..srgba });
-///             Ok(ResPut(ClearColor(color)))
+///             Ok(ResSet(ClearColor(color)))
 ///         }
 ///         _ => Err("color is not srgba"),
 ///     };

--- a/src/effects/iter.rs
+++ b/src/effects/iter.rs
@@ -52,7 +52,7 @@ mod tests {
     use proptest::prelude::*;
 
     use crate::effects::number_data::NumberComponent;
-    use crate::effects::{CommandSpawnAnd, EventWrite, ResPut};
+    use crate::effects::{CommandSpawnAnd, EventWrite, ResSet};
     use crate::prelude::affect;
 
     proptest! {
@@ -90,7 +90,7 @@ mod tests {
                 Update,
                 (|num_updates: Res<NumUpdates>| {
                     (
-                        ResPut(NumUpdates(num_updates.0 + 1)),
+                        ResSet(NumUpdates(num_updates.0 + 1)),
                         (num_updates.0 % 2 == 0).then_some(EventWrite(UpdateIsEven)),
                     )
                 })

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -3,16 +3,16 @@
 //! [`Effect`]: crate::Effect
 
 mod resource;
-pub use resource::{ResPut, ResWith};
+pub use resource::{ResSet, ResSetWith};
 
 mod event;
 pub use event::EventWrite;
 
 mod components;
-pub use components::{ComponentsPut, ComponentsWith};
+pub use components::{ComponentsSet, ComponentsSetWith};
 
 mod entity_components;
-pub use entity_components::{EntityComponentsPut, EntityComponentsWith};
+pub use entity_components::{EntityComponentsSet, EntityComponentsSetWith};
 
 mod command;
 pub use command::{CommandInsertResource, CommandQueue, CommandRemoveResource, CommandSpawnAnd};

--- a/src/effects/number_data.rs
+++ b/src/effects/number_data.rs
@@ -13,7 +13,7 @@ pub struct NumberComponent<const MARKER: usize>(pub u128);
 
 /// Returns a transform for a pair of [`NumberComponent`]s using the [`OneWayFn`]s.
 ///
-/// Can be used for validating a `-ComponentsWith` that uses
+/// Can be used for validating a `-ComponentsSetWith` that uses
 /// [`two_number_components_one_way_transform_with_void_query_data`].
 pub fn two_number_components_one_way_transform(
     f0: OneWayFn,
@@ -26,7 +26,7 @@ pub fn two_number_components_one_way_transform(
 
 /// Returns a transform for a pair of [`NumberComponent`]s and () using the [`OneWayFn`]s.
 ///
-/// Can be used as the function stored in a `-ComponentsWith` effect.
+/// Can be used as the function stored in a `-ComponentsSetWith` effect.
 pub fn two_number_components_one_way_transform_with_void_query_data(
     f0: OneWayFn,
     f1: OneWayFn,
@@ -38,7 +38,7 @@ pub fn two_number_components_one_way_transform_with_void_query_data(
 /// Returns a function taking a [`NumberComponent`] with `MARKER=0` and returning a `MARKER=1`
 /// using the [`OneWayFn`].
 ///
-/// Can be used for validating a `-ComponentsWith` that uses
+/// Can be used for validating a `-ComponentsSetWith` that uses
 /// [`n0_query_data_to_n1_through_one_way_function`].
 pub fn n0_to_n1_through_one_way_function(
     f: OneWayFn,
@@ -49,7 +49,7 @@ pub fn n0_to_n1_through_one_way_function(
 /// Returns a function transforming a `(NumberComponent<1>,)` from a `&NumberComponent<0>` using
 /// the [`OneWayFn`].
 ///
-/// Can be used as the function stored in a `-ComponentsWith` effect.
+/// Can be used as the function stored in a `-ComponentsSetWith` effect.
 pub fn n0_query_data_to_n1_through_one_way_function(
     f: OneWayFn,
 ) -> impl Fn((NumberComponent<1>,), &NumberComponent<0>) -> (NumberComponent<1>,) {

--- a/src/effects/resource.rs
+++ b/src/effects/resource.rs
@@ -7,11 +7,11 @@ use crate::effect::Effect;
 
 /// [`Effect`] that sets a `Resource` to the provided value.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub struct ResPut<R>(pub R)
+pub struct ResSet<R>(pub R)
 where
     R: Resource;
 
-impl<R> Effect for ResPut<R>
+impl<R> Effect for ResSet<R>
 where
     R: Resource,
 {
@@ -24,7 +24,7 @@ where
 
 /// [`Effect`] that transforms a `Resource` with the provided function.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub struct ResWith<F, R>
+pub struct ResSetWith<F, R>
 where
     F: FnOnce(R) -> R,
     R: Resource + Clone,
@@ -33,21 +33,21 @@ where
     phantom: PhantomData<R>,
 }
 
-impl<F, R> ResWith<F, R>
+impl<F, R> ResSetWith<F, R>
 where
     F: FnOnce(R) -> R,
     R: Resource + Clone,
 {
-    /// Construct a new [`ResWith`].
+    /// Construct a new [`ResSetWith`].
     pub fn new(f: F) -> Self {
-        ResWith {
+        ResSetWith {
             f,
             phantom: PhantomData,
         }
     }
 }
 
-impl<F, R> Effect for ResWith<F, R>
+impl<F, R> Effect for ResSetWith<F, R>
 where
     F: FnOnce(R) -> R,
     R: Resource + Clone,
@@ -76,7 +76,7 @@ mod tests {
             prop_assume!(initial != put);
 
             app.insert_resource(initial)
-                .add_systems(Update, (move || ResPut(put)).pipe(affect));
+                .add_systems(Update, (move || ResSet(put)).pipe(affect));
 
             prop_assert_eq!(app.world().resource::<NumberResource>(), &initial);
 
@@ -93,7 +93,7 @@ mod tests {
 
             app.insert_resource(initial.clone()).add_systems(
                 Update,
-                (move || ResWith::new(move |NumberResource(n)| NumberResource(f.call(n)))).pipe(affect),
+                (move || ResSetWith::new(move |NumberResource(n)| NumberResource(f.call(n)))).pipe(affect),
             );
 
             prop_assert_eq!(app.world().resource::<NumberResource>(), &initial);

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,17 +9,17 @@ pub use crate::effects::{
     CommandQueue,
     CommandRemoveResource,
     CommandSpawnAnd,
-    ComponentsPut,
-    ComponentsWith,
+    ComponentsSet,
+    ComponentsSetWith,
     EntityCommandDespawn,
     EntityCommandInsert,
     EntityCommandQueue,
     EntityCommandRemove,
-    EntityComponentsPut,
-    EntityComponentsWith,
+    EntityComponentsSet,
+    EntityComponentsSetWith,
     EventWrite,
-    ResPut,
-    ResWith,
+    ResSet,
+    ResSetWith,
 };
 pub use crate::system_combinators::{affect, and_compose};
 pub use crate::{Effect, EffectOut};

--- a/src/system_combinators.rs
+++ b/src/system_combinators.rs
@@ -16,7 +16,7 @@ use crate::{Effect, EffectOut};
 /// use bevy_pipe_affect::prelude::*;
 ///
 /// fn system_with_effects() -> impl Effect {
-///     ResPut(ClearColor(Color::BLACK))
+///     ResSet(ClearColor(Color::BLACK))
 /// }
 ///
 /// assert_is_system(system_with_effects.pipe(affect))
@@ -52,11 +52,11 @@ where
 /// use bevy_pipe_affect::prelude::*;
 ///
 /// fn system_with_effects() -> impl Effect {
-///     ResPut(ClearColor(Color::BLACK))
+///     ResSet(ClearColor(Color::BLACK))
 /// }
 ///
 /// fn another_system_with_effects() -> impl Effect {
-///     ResPut(UiScale(2.0))
+///     ResSet(UiScale(2.0))
 /// }
 ///
 /// assert_is_system(


### PR DESCRIPTION
`Put` terminology is traditionally used for "update or insert" logic. However, all of the existing `Put` effects are just "update", not "insert". `Set` isn't quite as forgiving, and is more appropriate for how these effects behave.

In a similar vein, `With` effects were just kind of confusing, `SetWith` is a bit more clear.
