### PR TITLE
feat: add effect_out constructor

### DIFF
--- a/src/effect_out.rs
+++ b/src/effect_out.rs
@@ -22,3 +22,11 @@ where
         EffectOut { effect, out: () }
     }
 }
+
+/// Construct a new [`EffectOut`].
+pub fn effect_out<E, O>(effect: E, out: O) -> EffectOut<E, O>
+where
+    E: Effect,
+{
+    EffectOut { effect, out }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ mod effect;
 pub use effect::Effect;
 
 mod effect_out;
-pub use effect_out::EffectOut;
+pub use effect_out::{effect_out, EffectOut};
 
 pub mod effects;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -45,4 +45,4 @@ pub use crate::effects::{
     ResSetWith,
 };
 pub use crate::system_combinators::{affect, and_compose, pure};
-pub use crate::{Effect, EffectOut};
+pub use crate::{effect_out, Effect, EffectOut};


### PR DESCRIPTION
All other types defined in this crate have module-level constructor functions, except for `EffectOut`. All this does is add such a constructor for consistency.
