### PR TITLE
docs: make rainbow-clear-color example more basic

### DIFF
--- a/examples/rainbow-clear-color.rs
+++ b/examples/rainbow-clear-color.rs
@@ -12,7 +12,7 @@ fn main() {
         .run();
 }
 
-/// In this system, the clear color is a pure function of time.
+/// This system defines the clear color as a pure function of time.
 fn rainbow_clear_color(time: Res<Time>) -> impl Effect {
     let color = Color::hsv(time.elapsed_secs() * 20.0, 0.7, 0.7);
     res_set(ClearColor(color))


### PR DESCRIPTION
This repository needs a minimal example, and the goal of the rainbow-clear-color example suits itself to this. Currently, it is more complicated as it was used to try out some of the utility of the library functions in-game. This change makes it a minimal example, and more complex examples will be included later.
