### PR TITLE
fix: feature-flag derive tests

### DIFF
--- a/tests/derive_compilation.rs
+++ b/tests/derive_compilation.rs
@@ -1,4 +1,5 @@
 //! Some basic `Effect`-deriving types that should compile.
+#![cfg(feature = "derive")]
 #![allow(dead_code, clippy::enum_variant_names)]
 
 use bevy::ecs::component::Mutable;


### PR DESCRIPTION
The derive tests cause `cargo test` w/o `--features derive` to fail, for obvious reasons. Ideally, no flag enabling/disabling should make things fail. This makes `cargo test` work again by hiding the derive tests behind the `derive` feature flag.
