### PR TITLE
fix: test no-default-features in CI test job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev
-      - name: Run cargo test
+      - name: Run cargo test --no-default-features
+        run: cargo test --no-default-features
+      - name: Run cargo test --all-features
         run: cargo test --all-features
 
   clippy_check:


### PR DESCRIPTION
Currently, only `cargo test --all-features` is run in the test CI job. However, we recently had an issue with the compilation of tests with no features enabled. This makes sure this won't happen again by adding a simple `cargo test --no-default-features` step to the job.
