### PR TITLE
feat: derive common traits for EffectOut

### DIFF
--- a/src/effect_out.rs
+++ b/src/effect_out.rs
@@ -4,6 +4,7 @@ use crate::effect::Effect;
 ///
 /// Can be returned by `bevy` systems to produce effects with `E` while preserving normal pipe
 /// functionality with `O`.
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
 pub struct EffectOut<E, O>
 where
     E: Effect,


### PR DESCRIPTION
The rust API guidelines generally recommend to derive certain common traits for all types unless there is a good reason not to. This derives the 6 most common `std` traits for `EffectOut`, which should have had them in the first place.
