### PR TITLE
feat: improve naming and documentation of system combinators

### DIFF
--- a/src/effect_composition.rs
+++ b/src/effect_composition.rs
@@ -1,6 +1,8 @@
-//! [`Effect`] composition functions, that can be used with [`and_compose`].
+//! [`Effect`] composition functions, that can be used with [`in_and_then_compose`] and
+//! [`EffectOut::and_then_compose`].
 //!
-//! [`and_compose`]: crate::system_combinators::and_compose
+//! [`in_and_then_compose`]: crate::system_combinators::in_and_then_compose
+//! [`EffectOut::and_then_compose`]: crate::EffectOut::and_then_compose
 
 use bevy::ecs::error::{BevyError, ErrorContext};
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -46,5 +46,5 @@ pub use crate::effects::{
     res_set,
     res_set_with,
 };
-pub use crate::system_combinators::{affect, and_combine, and_compose, pure};
+pub use crate::system_combinators::{affect, in_and_then, in_and_then_compose, pure};
 pub use crate::{Effect, EffectOut, effect_out};


### PR DESCRIPTION
After writing the `EffectOut` composition methods, it became clear that `and_compose` and `and_combine` were actually analogous to `EffectOut::and_then_compose` and `EffectOut::and_then`. I think it would be nice if their names were in homage as well. However, just calling them module functions with those names and putting them in the prelude would be presumptuous, especially a name such as common as `and_then`. So, to individuate them and also express that they are intended for pipe input, the `in_` prefix is used.

Documentation across the module has also been adjusted here to be more similar to the standards set by the `EffectOut` changes.
