### PR TITLE
docs: use Effect derive to simplify effect_composition doc tests

### DIFF
--- a/src/effect_composition.rs
+++ b/src/effect_composition.rs
@@ -6,8 +6,8 @@
 
 use bevy::ecs::error::{BevyError, ErrorContext};
 
-use crate::effects::AffectOrHandle;
 use crate::Effect;
+use crate::effects::AffectOrHandle;
 
 /// [`Effect`] composition function that returns the first effect.
 ///


### PR DESCRIPTION
Before `Effect` was derivable, making a custom resource or message and using `res_set` or `message_write` were the quickest ways to make dummy effects for tests. The effect derive allows us to make `Effect` types more directly, so now it can be used to simplify some of the code examples. This changes the effect-composition module's doctests to use simple `MyEffect` types.
