### PR TITLE
feat: implement IntoIterator for AffectMany

### DIFF
--- a/src/effects/iter.rs
+++ b/src/effects/iter.rs
@@ -38,6 +38,19 @@ where
     }
 }
 
+impl<I> IntoIterator for AffectMany<I>
+where
+    I: IntoIterator,
+    I::Item: Effect,
+{
+    type Item = I::Item;
+    type IntoIter = I::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter.into_iter()
+    }
+}
+
 impl<E> Effect for Vec<E>
 where
     E: Effect,


### PR DESCRIPTION
`AffectMany` is just a wrapper around a generic `I: IntoIterator`. So, it makes sense for it to also implement `IntoIterator`.

I considered also making it implement `FromIterator`, but this doesn't seem as obviously good. In any situation where this would be ergonomic, the target `I` parameter would still need to be supplied. So, I'm leaving it be for now.
