### PR TITLE
ci: add basic release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,7 +8,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@v4
         with:
           token: ${{ secrets.PAT }}
           release-type: rust


### PR DESCRIPTION
I've used release-please to great affect in other rust repositories. This will help automate the tagging of releases and managing of changelogs and triggering other jobs to run on releases.
