### PR TITLE
fix: move release-please config to config file

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,14 +1,13 @@
 {
-  "bump-minor-pre-major": true,
-  "extra-files": ["README.md"],
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",
       "release-type": "rust",
-      "bump-minor-pre-major": false,
+      "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": false,
       "draft": false,
-      "prerelease": false
+      "prerelease": false,
+      "extra-files": ["README.md"]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
Initial runs of the release-please workflow result in some warnings about deprecations and the use of certain config options in the job. It turns out, release-please v4 requires many of the configuration options to be specified in the config file itself. This change moves those configurations to the config file, and also uses the newer location for the release-please-action as the current one is deprecated.
