### PR TITLE
feat: add book with outline

### DIFF
--- a/book/.gitignore
+++ b/book/.gitignore
@@ -1,0 +1,2 @@
+book
+doctest_cache

--- a/book/book.toml
+++ b/book/book.toml
@@ -1,0 +1,12 @@
+[book]
+authors = ["Trevor Lovell"]
+language = "en"
+multilingual = false
+src = "src"
+title = "bevy_pipe_affect Book"
+
+[preprocessor.keeper]
+command = "mdbook-keeper"
+after = ["links"]
+manifest_dir = "."
+externs = ["bevy", "bevy_pipe_affect"]

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -1,0 +1,15 @@
+# Summary
+
+[Introduction]()
+# Tutorials
+- [Alien Cake Addict Refactor]()
+# Explanation
+- [Motivation and Theory]()
+- [Output and Effect Composition]()
+- [Return Types]()
+# How-To Guides
+- [Create a custom Effect]()
+- [Create a Relation]()
+- [Create an Observer]()
+---
+[API Reference]()


### PR DESCRIPTION
I would like to start on the right foot when it comes to documentation of this library. This means having a place separate from the API reference for writing tutorials, guides, and explanation docs. I've used mdbook for this in the past to good effect, so I'm doing the same here. This adds an mdbook to the repo with nothing but a simple outline.
