### PR TITLE
feat(ci): add mdbook tests to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,3 +99,31 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev
       - name: Run cargo doc
         run: cargo doc --no-deps
+
+  # Run mdbook build (tests all code snippets)
+  build-test-book:
+    name: Build and test book
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-mdbook-build-${{ hashFiles('**/Cargo.toml') }}
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install mdbook
+        uses: peaceiris/actions-mdbook@v2
+        with:
+          mdbook-version: '0.4.35'
+      - name: Install mdbook-keeper
+        run: cargo install mdbook-keeper --git https://github.com/tfpk/mdbook-keeper/ --rev 12f116d0840c69a6786dba3865768af3fde634f3 --force
+      - name: Test mdbook code snippets
+        run: bash ./ci/test-book.sh

--- a/ci/test-book.sh
+++ b/ci/test-book.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+CARGO_MANIFEST_DIR=. mdbook build book 2>&1 | tee test-book-err
+
+failures=$( grep '\(Panicked\|Failed\)' test-book-err )
+
+if [[ -n $failures ]]; then
+    echo "CI: stderr contained failures"
+    rm test-book-err
+    exit 1
+else
+    echo "CI: no failures detected in stderr"
+    rm test-book-err
+fi


### PR DESCRIPTION
The book will contain some code examples that should be tested. This can be checked on every pull request with the help of mdbook-keeper. This adds such a job to the CI workflows.
