### PR TITLE
fix(ci): give publish-book workflow write permissions

### DIFF
--- a/.github/workflows/publish-book.yml
+++ b/.github/workflows/publish-book.yml
@@ -7,6 +7,9 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  contents: write
+
 jobs:
   publish-book:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The first attempt to deploy the mdbook failed due to a lack of permissions. This change should give the `GITHUB_TOKEN` the correct permissions to push changes to the gh-pages branch.
