### PR TITLE
ci: add more changelog-sections for representing non-src changes in changelog

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,14 @@
       "bump-patch-for-minor-pre-major": false,
       "draft": false,
       "prerelease": false,
-      "extra-files": ["README.md"]
+      "extra-files": ["README.md"],
+      "changelog-sections": [
+        {"type": "feat", "section": "Features"},
+        {"type": "fix", "section": "Bug Fixes"},
+        {"type": "book", "section": "Book Changes"},
+        {"type": "example", "section": "Example Changes"},
+        {"type": "ci", "section": "CI Changes"}
+      ]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
For the most part, we want the semver versions to respond to "fix" and "feat" and "fix!" and "feat!" commit messages. However, there are many changes that have nothing to do with the actual interface we're versioning that I would still like to have represented in the changelog, at least for recognition's sake when someone contributes. This adds some changelog-sections configuration that should capture all the non-src, non-crate changes in release-please.
