### PR TITLE
ci: add test section to release-please-config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,7 +13,8 @@
         {"type": "fix", "section": "Bug Fixes"},
         {"type": "book", "section": "Book Changes"},
         {"type": "example", "section": "Example Changes"},
-        {"type": "ci", "section": "CI Changes"}
+        {"type": "ci", "section": "CI Changes"},
+        {"type": "test", "section": "Test Changes"}
       ]
     }
   },


### PR DESCRIPTION
Occasionally, changes may be made that only affect tests. Since tests are not compiled for user consumption, these should not count towards the core `feat`/`fix` release-please sections. This adds a changelog section `test` so that these sorts of changes can be represented in the changelog still.
