### PR TITLE
example: require bevy default features for examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,11 @@ blake2 = "0.10.6"
 
 [features]
 derive = ["bevy_pipe_affect_derive"]
+
+[[example]]
+name = "rainbow-clear-color"
+required-features = ["bevy/default"]
+
+[[example]]
+name = "relationship"
+required-features = ["bevy/default"]


### PR DESCRIPTION
The examples currently don't run unless you pass in `--features bevy/default`, after the bevy features were somewhat minimized. This change simply requires that feature to be enabled for the two existing examples to run at all.
