### PR TITLE
book: write 'Spawn a Relationship Synchronously' chapter

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -9,7 +9,7 @@
 - [Return Types]()
 # How-To Guides
 - [Create a custom Effect]()
-- [Create a Relation]()
+- [Spawn a Relationship Synchronously](how-to-guides/spawn-a-relationship-synchronously.md)
 - [Create an Observer]()
 ---
 [API Reference]()

--- a/book/src/how-to-guides/spawn-a-relationship-synchronously.md
+++ b/book/src/how-to-guides/spawn-a-relationship-synchronously.md
@@ -1,0 +1,15 @@
+# Spawn a Relationship Synchronously
+Bevy relationships may be spawned using specialized commands, like `with_children` or `with_related_entities`.
+`bevy_pipe_affect` APIs are more minimal, but these situations can still be handled ergonomically:
+1. Return an effect that spawns the entity that will be the `RelationshipTarget` with `command_spawn_and`. In the `Parent`/`ChildOf` relationship, this will become the `Parent` entity. That component does not need to be provided, it will be created by Bevy.
+2. Provide a closure to the second argument of the `command_spawn_and` call that returns another `command_spawn-` effect that will spawn the `Relationship` entity. In the `Parent`/`ChildOf` relationship, this is the `ChildOf` entity. This time, you do need to provide that component with the `Entity` provided to the closure (this will be `RelationshipTarget` `Entity`, spawned in step 1).
+
+The `relationship` example does this, while also bundling some sprites/marker components:
+```rust
+# #[derive(Component)] struct Spinny;
+use bevy::prelude::*;
+use bevy_pipe_affect::prelude::*;
+
+{{#include ../../../examples/relationship.rs:spawn_relationship}}
+# fn main() { bevy::ecs::system::assert_is_system(spawn_relationship.pipe(affect)) }
+```

--- a/examples/relationship.rs
+++ b/examples/relationship.rs
@@ -9,6 +9,7 @@ fn spawn_camera() -> impl Effect {
     command_spawn(Camera2d)
 }
 
+// ANCHOR: spawn_relationship
 fn spawn_relationship() -> impl Effect {
     // We will give both entities a sprite, which we can load using this effect
     // We can use its handle to create more effects with a closure
@@ -23,15 +24,16 @@ fn spawn_relationship() -> impl Effect {
             ),
             |parent| {
                 command_spawn((
+                    ChildOf(parent), // This is where the relationship happens!
                     Spinny,
                     Sprite::from_image(image_handle),
-                    ChildOf(parent),
                     Transform::from_xyz(20.0, 20.0, 0.0).with_scale(Vec3::splat(0.5)),
                 ))
             },
         )
     })
 }
+// ANCHOR_END: spawn_relationship
 
 // This system defines the rotation of entities with a Spinny component to be a function of time.
 fn spin(time: Res<Time>) -> impl Effect + use<> {


### PR DESCRIPTION
One of the most important requirements for this library was being able to spawn relationships (especially hierarchys) synchronously, i.e., in one system. We now have an example demonstrating how to do this, but I wanted to tie this to some actual documentation as well. This creates a how-to-guide for doing such a thing, using the example's code.
