### PR TITLE
feat: implement FromIterator for EffectOut

### DIFF
--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -69,4 +69,4 @@ pub use error::{AffectOrHandle, affect_or_handle};
 mod one_way_fn;
 
 #[cfg(test)]
-mod number_data;
+pub mod number_data;


### PR DESCRIPTION
It's pretty common in bevy systems to iterate through queries, and with bevy_pipe_affect, users will likely be mapping those iterators to effects. If you're just returning a normal effect, this is fine because you can just collect the effects into a `Vec`. However, if you want an `EffectOut`, or are just doing some `EffectOut` composition within the map, the collection becomes a bit grosser.

This change implements `FromIterator` for `EffectOut`. More specifically, the source iterator needs to have `EffectOut` items, and the target effect and output need to be iterators.
