### PR TITLE
feat: add extend effect composition function

### DIFF
--- a/src/effect_composition.rs
+++ b/src/effect_composition.rs
@@ -105,7 +105,6 @@ where
     (e1, e0)
 }
 
-
 /// [`Effect`] composition function for extendable iterator effects that concatenates them.
 ///
 /// ```
@@ -130,12 +129,11 @@ where
 ///     ]
 /// );
 /// ```
-pub fn extend<E0, E1>(
-    mut e0: E0,
-    e1: E1,
-) -> E0
-    where E0: Extend<E1::Item> + Effect,
-          E1: IntoIterator + Effect {
+pub fn extend<E0, E1>(mut e0: E0, e1: E1) -> E0
+where
+    E0: Extend<E1::Item> + Effect,
+    E1: IntoIterator + Effect,
+{
     e0.extend(e1);
     e0
 }


### PR DESCRIPTION
Effects like `Vec` and other iterators will be pretty commonly used in the library. So, to keep the typing of composed effects simple, users may want to simply compose these effects by concatenating their iterators. This provides an effect composition function for doing so, `extend`.
