### PR TITLE
feat: add in_and_extend system combinator

### DIFF
--- a/src/system_combinators.rs
+++ b/src/system_combinators.rs
@@ -202,6 +202,18 @@ where
     in_and_then_compose(s, combine)
 }
 
+/// Higher-order `bevy` system constructor for concatenating the iterator effects of two systems
+/// via piping.
+///
+/// Accepts an iterator-effect-returning system `s` and returns a system that concatenates the
+/// extendable-iterator effect of the piped-in system and `s`.
+///
+/// See [`in_and_then`] if you want to combine effects of heterogenous type. See
+/// [`in_and_then_compose`] for more effect composition flexibility.
+///
+/// If the piped-in system returns [`EffectOut<E, O>`] instead of a simple effect, then the
+/// `output: O` is passed into the given system `s`. This allows for a monad-ish API of chaining
+/// many systems and piping their outputs while concatenating their effects.
 pub fn in_and_extend<IntoEffectOut1, E1, O1, System, Marker, IntoEffectOut2, E2, O2>(
     s: System,
 ) -> impl FnMut(In<IntoEffectOut1>, StaticSystemParam<System::Param>) -> EffectOut<E1, O2>


### PR DESCRIPTION
`extend` will be a pretty commonly used effect composition function. So, it could use its own convenience function around `in_and_then_compose`. This adds `in_and_extend` to fulfill this purpose.
