### PR TITLE
feat: add EffectOut::and_extend method

### DIFF
--- a/src/effect_out.rs
+++ b/src/effect_out.rs
@@ -165,13 +165,13 @@ where
     pub fn and_extend<IntoEffectOut, EIter, O2>(
         self,
         f: impl FnOnce(O) -> IntoEffectOut,
-        ) -> EffectOut<E, O2>
-        where 
-            EIter: IntoIterator + Effect,
-            EIter::Item: Effect,
-            E: Extend<EIter::Item>,
-            IntoEffectOut: Into<EffectOut<EIter, O2>>
-        {
+    ) -> EffectOut<E, O2>
+    where
+        EIter: IntoIterator + Effect,
+        EIter::Item: Effect,
+        E: Extend<EIter::Item>,
+        IntoEffectOut: Into<EffectOut<EIter, O2>>,
+    {
         self.and_then_compose(f, extend)
     }
 }


### PR DESCRIPTION
`extend` will be a pretty commonly used effect composition function. So, it could use its own convenience function around `EffectOut::and_then_compose`. This adds `EffectOut::and_extend` to fulfill this purpose.

This actually makes `EffectOut` (with an extendable iterator effect) a monad. `and_extend` is the bind operation.
