### PR TITLE
feat: implement Extend for AffectMany

### DIFF
--- a/src/effects/iter.rs
+++ b/src/effects/iter.rs
@@ -51,6 +51,16 @@ where
     }
 }
 
+impl<I, E> Extend<E> for AffectMany<I>
+where
+    I: IntoIterator<Item = E> + Extend<E>,
+    E: Effect,
+{
+    fn extend<T: IntoIterator<Item = E>>(&mut self, iter: T) {
+        self.iter.extend(iter)
+    }
+}
+
 impl<E> Effect for Vec<E>
 where
     E: Effect,


### PR DESCRIPTION
Now we have some generic composition functions for iterators that implement `Extend`. `AffectMany` doesn't implement `Extend`, but it could if its internal iterator does, allowing it to be used in these new generic functions. This change does that implementation.
