### PR TITLE
feat: add in_and_extend to prelude

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -48,5 +48,11 @@ pub use crate::effects::{
     res_set,
     res_set_with,
 };
-pub use crate::system_combinators::{affect, in_and_then, in_and_then_compose, pure};
+pub use crate::system_combinators::{
+    affect,
+    in_and_extend,
+    in_and_then,
+    in_and_then_compose,
+    pure,
+};
 pub use crate::{Effect, EffectOut, effect_out};


### PR DESCRIPTION
The `in_and_extend` system combinator is an important one, as it allows for monadic `EffectOut` composition between systems. It should have been included in the prelude, but it slipped through the cracks. This change adds it.
