### PR TITLE
ci: upgrade mdbook to 0.4.52 and mdbook-keeper to 0.5.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,6 +124,6 @@ jobs:
         with:
           mdbook-version: '0.4.52'
       - name: Install mdbook-keeper
-        run: cargo install mdbook-keeper@0.5.0
+        run: cargo install mdbook-keeper@0.5.0 --force
       - name: Test mdbook code snippets
         run: bash ./ci/test-book.sh

--- a/.github/workflows/publish-book.yml
+++ b/.github/workflows/publish-book.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           mdbook-version: '0.4.52'
       - name: Install mdbook-keeper
-        run: cargo install mdbook-keeper@0.5.0
+        run: cargo install mdbook-keeper@0.5.0 --force
       - name: test and build book
         run: bash ./ci/test-book.sh
       - name: Publish


### PR DESCRIPTION
There are new features of mdbook-keeper that I would like to use in the upcoming book chapter. This change upgrades mdbook-keeper to 0.5.0 accordingly. This version of mdbook-keeper was built on the latest 0.4 mdbook, so this also upgrades to that version of mdbook.
