### PR TITLE
ci: install bevy system dependencies for book jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,6 +119,8 @@ jobs:
           key: ${{ runner.os }}-mdbook-build-${{ hashFiles('**/Cargo.toml') }}
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+      - name: Install Dependencies
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev
       - name: Install mdbook
         uses: peaceiris/actions-mdbook@v2
         with:

--- a/.github/workflows/publish-book.yml
+++ b/.github/workflows/publish-book.yml
@@ -28,6 +28,8 @@ jobs:
           key: ${{ runner.os }}-mdbook-publish-${{ hashFiles('**/Cargo.toml') }}
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+      - name: Install Dependencies
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev
       - name: Install mdbook
         uses: peaceiris/actions-mdbook@v2
         with:


### PR DESCRIPTION
The CI jobs for building the book, running the code snippets, and publishing are silently failing due to missing system dependencies. This change adds the same dependency installation step that the other CI jobs have to the book jobs.
