### PR TITLE
book: add chapter that redirects to api reference

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -12,4 +12,4 @@
 - [Spawn a Relationship Synchronously](how-to-guides/spawn-a-relationship-synchronously.md)
 - [Create an Observer]()
 ---
-[API Reference]()
+[API Reference](api-reference.md)

--- a/book/src/api-reference.md
+++ b/book/src/api-reference.md
@@ -1,0 +1,1 @@
+<meta http-equiv="Refresh" content="0; url='https://docs.rs/bevy_pipe_affect/0.1.0/bevy_pipe_affect'" /><!-- x-release-please-version -->

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,8 @@
       "prerelease": false,
       "extra-files": [
         "README.md",
-        "book/src/README.md"
+        "book/src/README.md",
+        "book/src/api-reference.md"
       ],
       "changelog-sections": [
         {"type": "feat", "section": "Features"},


### PR DESCRIPTION
The book should make the api reference easily accessible at any time. There is a place-holder chapter just for this. This change makes that placeholder chapter a simple redirect to the (yet to be published) api reference.
