### PR TITLE
fix: describe documentation and add links in api reference

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,8 @@
       "extra-files": [
         "README.md",
         "book/src/README.md",
-        "book/src/api-reference.md"
+        "book/src/api-reference.md",
+        "src/lib.rs"
       ],
       "changelog-sections": [
         {"type": "feat", "section": "Features"},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,16 @@
 #![doc = include_str!("../book/src/blurb.md")]
+//!
+//! ## This API Reference
+//! The purpose of this API reference is to describe the API provided by this library.
+//! More explanation-oriented documentation, tutorials, and guides are available in the
+//! [`bevy_pipe_affect` book](https://trouv.github.io/bevy_pipe_affect/v0.1.0). <!-- x-release-please-version -->
+//!
+//! The following are good jumping-off points for beginners:
+//! - [*Motivations* explanation](https://trouv.github.io/bevy_pipe_affect/v0.1.0/explanation/motivations.html) <!-- x-release-please-version -->
+//! - [*effects* module api reference](effects) (a list of effects and constructors provided by the library)
+//!
+//! Cargo examples are also available in this library's
+//! [github repository](https://github.com/Trouv/bevy_pipe_affect/tree/v0.1.0/examples). <!-- x-release-please-version -->
 #![warn(missing_docs)]
 #![deny(rustdoc::all)]
 


### PR DESCRIPTION
All documentation should be discoverable from other documentation. Now the book links to the api reference, and the api reference should link to the book. This change adds those links, and also generally describes the purpose of the book vs the api reference.
