### PR TITLE
book: describe documentation and add links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,20 @@ All mutability can be _piped out_ of your code.
 The initial set of effects and utilities have been created.
 See #47 for the remainder of the planned work before the initial release.
 
+## Documentation
+Documentation for this library is available in two main places.
+- API reference on [docs.rs](https://docs.rs/bevy_pipe_affect/0.1.0/bevy_pipe_affect/) <!-- x-release-please-version -->
+- Tutorials, Explanation, and Guides in the [`bevy_pipe_affect` book](https://trouv.github.io/bevy_pipe_affect/main/index.html)
+
+The following are good jumping-off points for beginners:
+- [*Motivations* explanation](https://trouv.github.io/bevy_pipe_affect/main/explanation/motivations.html)
+- [*effects* module api reference](https://docs.rs/bevy_pipe_affect/0.1.0/bevy_pipe_affect/effects/index.html) (a list of effects and constructors provided by the library) <!-- x-release-please-version -->
+
+Cargo examples are also available in this repository:
+```sh
+$ cargo run --example example-name --release --features bevy/default
+```
+
 ## License
 
 Except where noted, all code in this repository is dual-licensed under either:


### PR DESCRIPTION
All documentation for this library should be discoverable. This adds links to the book and api reference to the project README.md, which will also be seen on crates.io. For now, the `main` branch of the book is linked to, so that prospective users will actually be able to click this link before release.
