### PR TITLE
fix: note that variadics_please and either are already included by bevy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,14 @@ members = ["effect_derive"]
 
 [dependencies]
 bevy = { version = "0.17.3", default-features = false }
-variadics_please = "1.1.0"
-either = "1.15.0"
 bevy_pipe_affect_derive = { version = "0.1.0", path = "effect_derive", optional = true }
 
+# bevy with no default features actually depends on both of these, no need to hide them behind flags
+variadics_please = "1.1.0"
+either = "1.15.0"
+
 [dev-dependencies]
-bevy = { version = "0.17.3", default-feature = true }
+bevy = { version = "0.17.3" }
 proptest = "1.8.0"
 proptest-derive = "0.6.0"
 blake2 = "0.10.6"


### PR DESCRIPTION
I was originally planning to hide the Either effect and dependency behind a feature flag. However, it turns out that, even with no default features, bevy will bring in the either dependency. So, it's not really worth it to make a feature flag out of it, which I've noted here.
