### PR TITLE
feat: define packages with more detail

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "bevy_pipe_affect"
+description = "Write systems as pure functions."
 version = "0.1.0"
 edition = "2024"
+authors = ["Trevor Lovell <trevorlovelldesign@gmail.com>"]
+repository = "https://github.com/Trouv/bevy_pipe_affect"
+license = "MIT OR Apache-2.0"
+keywords = ["bevy", "game", "gamedev"]
+categories = ["game-development"]
+exclude = ["assets/", "ci/", ".github/"]
 
 [workspace]
 members = ["effect_derive"]
@@ -27,3 +34,6 @@ asset_server = ["bevy/bevy_asset"]
 [[example]]
 name = "relationship"
 required-features = ["asset_server"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/effect_derive/Cargo.toml
+++ b/effect_derive/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "bevy_pipe_affect_derive"
+description = "Effect derive macro for bevy_pipe_affect."
 version = "0.1.0"
 edition = "2024"
+authors = ["Trevor Lovell <trevorlovelldesign@gmail.com>"]
+license = "MIT OR Apache-2.0"
+keywords = ["bevy", "game", "gamedev"]
+categories = ["game-development"]
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
The cargo packages defined in this repo are currently pretty minimal. This change adds several details to the package definitions to improve their visibility and completeness on crates.io. It also enables all-features for the docs.rs build.
