### PR TITLE
example: add observer example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,5 +35,9 @@ asset_server = ["bevy/bevy_asset"]
 name = "relationship"
 required-features = ["asset_server"]
 
+[[example]]
+name = "observer"
+required-features = ["asset_server"]
+
 [package.metadata.docs.rs]
 all-features = true

--- a/examples/observer/inflatable.rs
+++ b/examples/observer/inflatable.rs
@@ -1,0 +1,34 @@
+use bevy::prelude::*;
+use bevy_pipe_affect::prelude::*;
+
+// ANCHOR: event
+#[derive(Event)]
+pub struct InflateEvent;
+// ANCHOR_END: event
+
+// ANCHOR: observer_system
+#[derive(Component)]
+pub struct Inflatable;
+
+fn inflate(_event: On<InflateEvent>) -> impl Effect + use<> {
+    components_set_filtered_with::<_, _, With<Inflatable>>(|(transform,): (Transform,)| {
+        (transform.with_scale(transform.scale * 1.1),)
+    })
+}
+// ANCHOR_END: observer_system
+
+// ANCHOR: spawn_observer
+pub fn spawn_observer() -> impl Effect {
+    command_spawn(Observer::new(inflate.pipe(affect)))
+}
+// ANCHOR_END: spawn_observer
+
+// ANCHOR: trigger_observer
+pub fn trigger_observer(input: Res<ButtonInput<KeyCode>>) -> Option<CommandTrigger<InflateEvent>> {
+    if input.just_pressed(KeyCode::Space) {
+        Some(command_trigger(InflateEvent))
+    } else {
+        None
+    }
+}
+// ANCHOR_END: trigger_observer

--- a/examples/observer/main.rs
+++ b/examples/observer/main.rs
@@ -1,0 +1,27 @@
+//! Basic example of pure observer usage.
+//!
+//! Snippets of this are used in the *Spawn and Trigger an Observer* how-to-guide in the book.
+
+use bevy::prelude::*;
+use bevy_pipe_affect::prelude::*;
+
+use crate::inflatable::{Inflatable, spawn_observer, trigger_observer};
+
+mod inflatable;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
+        .add_systems(Startup, (setup.pipe(affect), spawn_observer.pipe(affect)))
+        .add_systems(Update, trigger_observer.pipe(affect))
+        .run();
+}
+
+pub fn setup() -> impl Effect {
+    (
+        command_spawn(Camera2d::default()),
+        asset_server_load_and("player.png", |sprite| {
+            command_spawn((Sprite::from_image(sprite), Inflatable))
+        }),
+    )
+}


### PR DESCRIPTION
While the sokoban example does use observers, it is a bit too complicated to server as an example of basic observer usage. This change adds a much simpler example of observer usage, which will soon be used as code snippets in the book.
