### PR TITLE
fix: document feature flags

### DIFF
--- a/src/effect.rs
+++ b/src/effect.rs
@@ -5,6 +5,8 @@ use bevy::ecs::system::SystemParam;
 /// Can be returned by `bevy` systems and `pipe`d into [`affect`] to perform the transition.
 ///
 /// # Derive
+/// *Requires the `derive` feature to be enabled.*
+///
 /// More complex effects can be derived for structs and enums whose fields also implement `Effect`,
 /// if the `derive` cargo feature is enabled.
 ///

--- a/src/effects/asset_server.rs
+++ b/src/effects/asset_server.rs
@@ -9,6 +9,8 @@ use crate::Effect;
 /// effect-producing function to cause another effect.
 ///
 /// Can be constructed with [`asset_server_load_and`].
+///
+/// *Requires the `asset_server` feature to be enabled.*
 pub struct AssetServerLoadAnd<'a, F, A, E>
 where
     F: FnOnce(Handle<A>) -> E,
@@ -41,6 +43,8 @@ where
 }
 
 /// Construct a new [`AssetServerLoadAnd`] [`Effect`], with an extra effect using the `Handle<A>`.
+///
+/// *Requires the `asset_server` feature to be enabled.*
 pub fn asset_server_load_and<'a, P, F, A, E>(path: P, f: F) -> AssetServerLoadAnd<'a, F, A, E>
 where
     P: Into<AssetPath<'a>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,16 @@
 //!
 //! Cargo examples are also available in this library's
 //! [github repository](https://github.com/Trouv/bevy_pipe_affect/tree/v0.1.0/examples). <!-- x-release-please-version -->
+//!
+//! ## Feature flags
+//! This crate provides the following set of [feature flags]:
+//! - `derive`: enables the [`Effect`] derive macro for structs and enums of effects
+//! - `asset_server`: enables the `bevy/bevy_asset` feature and [`AssetServer`-related effects]
+//!
+//! None of these are enabled by default.
+//!
+//! [feature flags]: https://doc.rust-lang.org/cargo/reference/features.html#the-features-section
+//! [`AssetServer`-related effects]: effects::AssetServerLoadAnd
 #![warn(missing_docs)]
 #![deny(rustdoc::all)]
 
@@ -29,5 +39,7 @@ pub mod effect_composition;
 pub mod prelude;
 
 /// Derive macro for the [`Effect`] trait. See that trait for more details.
+///
+/// *Requires the `derive` feature to be enabled.*
 #[cfg(feature = "derive")]
 pub use bevy_pipe_affect_derive::Effect;


### PR DESCRIPTION
The crate is releasing with a couple of disabled feature flags that currently aren't documented anywhere. This change documents them in the main page of the api reference.
