### PR TITLE
ci: enable all-features in doc_check job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,7 +98,7 @@ jobs:
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev
       - name: Run cargo doc
-        run: cargo doc --no-deps
+        run: cargo doc --no-deps --all-features
 
   # Run mdbook build (tests all code snippets)
   build-test-book:


### PR DESCRIPTION
If there's an intra-doc-link to an item behind a feature flag, the current doc_check CI job will fail. This job should enable all feature flags, just like the actual release will when it is published to docs.rs.
