### PR TITLE
fix: copy rainbow_clear_color example into README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,29 @@ This enables a more functional code-style in `bevy` app development.
 User-written systems can all be read-only, pure functions.
 All mutability can be _piped out_ of your code.
 
+*From the example `rainbow-clear-color`:*
+```rust
+use bevy::prelude::*;
+use bevy_pipe_affect::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_systems(
+            Update,
+            pure(rainbow_clear_color) // pure() is optional, just forces the system to be read-only
+                .pipe(affect),
+        )
+        .run();
+}
+
+/// This system defines the clear color as a pure function of time.
+fn rainbow_clear_color(time: Res<Time>) -> impl Effect + use<> {
+    let color = Color::hsv(time.elapsed_secs() * 20.0, 0.7, 0.7);
+    res_set(ClearColor(color))
+}
+```
+
 ## Development
 `bevy_pipe_affect` is nearing release.
 The initial set of effects and utilities have been created.


### PR DESCRIPTION
The README is currently lacking in marketing material. Prospective users should have a little bit of a better idea of what it's like to use the library, or what it provides them, at a glance of the README. This change just copies the rainbow_clear_color example into the README, which is a minimal demonstration of the library at work.
