### PR TITLE
fix: prepare README.md for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,18 +35,13 @@ fn rainbow_clear_color(time: Res<Time>) -> impl Effect + use<> {
 }
 ```
 
-## Development
-`bevy_pipe_affect` is nearing release.
-The initial set of effects and utilities have been created.
-See #47 for the remainder of the planned work before the initial release.
-
 ## Documentation
 Documentation for this library is available in two main places.
 - API reference on [docs.rs](https://docs.rs/bevy_pipe_affect/0.1.0/bevy_pipe_affect/) <!-- x-release-please-version -->
-- Tutorials, Explanation, and Guides in the [`bevy_pipe_affect` book](https://trouv.github.io/bevy_pipe_affect/main/index.html)
+- Tutorials, Explanation, and Guides in the [`bevy_pipe_affect` book](https://trouv.github.io/bevy_pipe_affect/v0.1.0/index.html) <!-- x-release-please-version -->
 
 The following are good jumping-off points for beginners:
-- [*Motivations* explanation](https://trouv.github.io/bevy_pipe_affect/main/explanation/motivations.html)
+- [*Motivations* explanation](https://trouv.github.io/bevy_pipe_affect/v0.1.0/explanation/motivations.html) <!-- x-release-please-version -->
 - [*effects* module api reference](https://docs.rs/bevy_pipe_affect/0.1.0/bevy_pipe_affect/effects/index.html) (a list of effects and constructors provided by the library) <!-- x-release-please-version -->
 
 Cargo examples are also available in this repository:
@@ -57,7 +52,7 @@ $ cargo run --release --all-features --example example-name
 ## Compatibility
 | bevy | bevy_pipe_affect |
 | --- | --- |
-| 0.17 | main |
+| 0.17 | 0.1 |
 
 ## License
 


### PR DESCRIPTION
Certain aspects of the README.md need to be updated before release to point to versioned links and have an accurate compatibility chart. This makes those changes.
