### PR TITLE
ci: exclude component in release-please tag

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,6 +7,7 @@
       "bump-patch-for-minor-pre-major": false,
       "draft": false,
       "prerelease": false,
+      "include-component-in-tag": false,
       "extra-files": [
         "README.md",
         "book/src/README.md",


### PR DESCRIPTION
Release please creates tags for new releases like `bevy_pipe_affect-v0.1.0`. However, certain pieces of documentation and automation have been under the assumption that the tags would instead be like `v0.1.0`, which was the `release-please` default behavior in previous versions. This meant that certain CI that is triggered by `v*.*.*` tags, like book publishing, did not trigger properly, and some links in documentation to certain github tags were broken. This attempts to address the issue by adjusting the release-please config to nod include the component name in the release tags.

Closes #94
