### PR TITLE
ci: rename book changelog section to docs

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -17,7 +17,7 @@
       "changelog-sections": [
         {"type": "feat", "section": "Features"},
         {"type": "fix", "section": "Bug Fixes"},
-        {"type": "book", "section": "Book Changes"},
+        {"type": "docs", "section": "Documentation Changes"},
         {"type": "example", "section": "Example Changes"},
         {"type": "ci", "section": "CI Changes"},
         {"type": "test", "section": "Test Changes"}


### PR DESCRIPTION
The current "book" changelog section wasn't intended to be used for API reference changes, but I think these should ultimately fall into the same category. After all, it's nice to reserve "fix" and "feat" for changes that actually affect the code that impacts users, and API ref changes don't really affect users.
