### PR TITLE
docs: enable minimal features in mdbook-keeper

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -10,4 +10,5 @@ command = "mdbook-keeper"
 after = ["links"]
 manifest_dir = "."
 externs = ["bevy", "bevy_pipe_affect"]
-build_features = ["asset_server", "bevy/default"]
+# be careful about enabling more features as the test builds quickly exceed github runner disk sizes
+build_features = ["asset_server", "bevy/bevy_camera", "bevy/bevy_sprite", "bevy/bevy_audio"]


### PR DESCRIPTION
As of bevy 0.18, build sizes for `bevy/default` quickly lead to a `book/doctest_cache` size of 16GiB. This exceeds github runner maximums, leading to CI failures. This attempts to resolve the issue by enabling minimum bevy features for mdbook-keeper, keeping the cache size down below 4GiB.
