### PR TITLE
docs: add 0.2 to compatibility chart in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ $ cargo run --release --all-features --example example-name
 ## Compatibility
 | bevy | bevy_pipe_affect |
 | --- | --- |
-| 0.18 | main |
+| 0.18 | 0.2 |
 | 0.17 | 0.1 |
 
 ## License


### PR DESCRIPTION
0.2 is ready to release, and the compatibility chart in the README.md needs to manually updated accordingly.
