### PR TITLE
feat!: box fn generics in entity_component effects

### DIFF
--- a/src/effects/entity_components.rs
+++ b/src/effects/entity_components.rs
@@ -125,6 +125,7 @@ all_tuples!(impl_effect_for_entity_components_set_with, 1, 15, C, c, r);
 /// If you do not need this extra query data, see [`EntityComponentsSetWith`].
 ///
 /// Can be constructed with [`entity_components_set_with_query_data`].
+#[derive(derive_more::Debug)]
 pub struct EntityComponentsSetWithQueryData<C, Data = ()>
 where
     C: Clone,
@@ -133,6 +134,8 @@ where
     /// The entity whose component is being set.
     pub entity: Entity,
     /// The function being applied to the component.
+    #[expect(clippy::type_complexity)]
+    #[debug("{0}, {1} -> {0}", std::any::type_name::<C>(), std::any::type_name::<<Data as QueryData>::Item<'static, 'static>>())]
     pub f: Box<dyn for<'w, 's> FnOnce(C, <Data as QueryData>::Item<'w, 's>) -> C + Send + Sync>,
 }
 


### PR DESCRIPTION
This change is part of a larger effort to use dynamic boxes for storing functions in effects instead of generics. Motivations for this are explained in f3a24e16929ae838940600fe9583e6275f2fde9f.
    
This change boxes the functions used in the `EntityComponentsSetWith` and `EntityComponentsSetWithQueryData` effects in particular.
