### PR TITLE
example: use concrete return type in animate_position system

### DIFF
--- a/examples/sokoban/animate.rs
+++ b/examples/sokoban/animate.rs
@@ -8,19 +8,19 @@ use crate::setup::BLOCK_SIZE;
 const ANIMATION_DECAY_RATE: f32 = 50.;
 
 /// Defines how visual positions of entities update based off their logical position.
-pub fn animate_position(time: Res<Time>) -> impl Effect + use<> {
+pub fn animate_position(
+    time: Res<Time>,
+) -> ComponentsSetWithQueryData<(Transform,), &'static Position> {
     let delta_secs = time.delta_secs();
-    components_set_with_query_data::<_, _, &Position>(
-        move |(mut transform,): (Transform,), position| {
-            // note: even though we we use mut here, there is still no side effect to this closure.
-            // This is because we take ownership of the transform instead of mutable reference.
-            let target = (position.as_vec2() * BLOCK_SIZE).extend(0.0);
+    components_set_with_query_data(move |(mut transform,): (Transform,), position: &Position| {
+        // note: even though we we use mut here, there is still no side effect to this closure.
+        // This is because we take ownership of the transform instead of mutable reference.
+        let target = (position.as_vec2() * BLOCK_SIZE).extend(0.0);
 
-            transform
-                .translation
-                .smooth_nudge(&target, ANIMATION_DECAY_RATE, delta_secs);
+        transform
+            .translation
+            .smooth_nudge(&target, ANIMATION_DECAY_RATE, delta_secs);
 
-            (transform,)
-        },
-    )
+        (transform,)
+    })
 }


### PR DESCRIPTION
Now that `ComponentsSetWithQueryData` has fewer generics, it is much more reasonable to express it concretely. This change takes advantage of this in the `sokoban` example, in particular the `animate_position` system.
