### PR TITLE
fix: remove Clone bound on QueryDataEffect of QueryEntityAffect

### DIFF
--- a/src/effects/query_entity.rs
+++ b/src/effects/query_entity.rs
@@ -136,7 +136,7 @@ where
 
 impl<QueryDataE, Filter> Effect for QueryEntityAffect<QueryDataE, Filter>
 where
-    QueryDataE: QueryDataEffect + Clone,
+    QueryDataE: QueryDataEffect,
     QueryDataE::MutQueryData: 'static,
     Filter: QueryFilter + 'static,
 {
@@ -154,7 +154,7 @@ where
             }
         };
 
-        self.query_data_effect.clone().affect(&mut query_data);
+        self.query_data_effect.affect(&mut query_data);
     }
 }
 


### PR DESCRIPTION
This `Clone` bound on the `QueryDataEffect` parameter of the `QueryEntityAffect` effect was a copy/paste mistake. It is a requirement for `QueryAffect` because the same effect needs to apply to many entities, but that's not the case for `QueryEntityAffect`.
