### PR TITLE
feat!: publicly organize effects into submodules

### DIFF
--- a/src/effect_composition.rs
+++ b/src/effect_composition.rs
@@ -7,7 +7,7 @@
 use bevy::ecs::error::BevyError;
 
 use crate::Effect;
-use crate::effects::AffectOrHandle;
+use crate::effects::error::AffectOrHandle;
 
 /// [`Effect`] composition function that returns the first effect.
 ///

--- a/src/effect_out.rs
+++ b/src/effect_out.rs
@@ -347,7 +347,7 @@ mod tests {
     use proptest::prelude::*;
 
     use super::*;
-    use crate::effects::message_write;
+    use crate::effects::message::message_write;
     use crate::effects::number_data::NumberMessage;
 
     proptest! {

--- a/src/effects/algebra.rs
+++ b/src/effects/algebra.rs
@@ -1,4 +1,18 @@
-//! Implements [`Effect`] for tuples of effects up to size 8.
+//! [`Effect`] implementations for generic algebraic data types.
+//!
+//! The implementations here are on these foreign types...
+//! - tuples of `Effect`s
+//! - `Either<Left, Right>` where the `Left` and `Right` are both effects
+//! - the unit type `()` (trivial no-op effect)
+//!
+//! It's also worth noting that `Option<T>` where `T: Effect` also implements [`Effect`], but that is
+//! implemented in the [`iter`] module.
+//!
+//! Also relevant, [`Effect`] [can be derived] for any custom `struct`/`enum` where the internal
+//! types implement [`Effect`].
+//!
+//! [`iter`]: crate::effects::iter
+//! [can be derived]: crate::effect::Effect#derive
 
 use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
@@ -50,7 +64,7 @@ mod tests {
 
     use super::*;
     use crate::effects::number_data::NumberResource;
-    use crate::effects::res_set;
+    use crate::effects::resource::res_set;
     use crate::prelude::affect;
 
     proptest! {

--- a/src/effects/asset_server.rs
+++ b/src/effects/asset_server.rs
@@ -1,3 +1,4 @@
+//! [`Effect`]s that operate on `Assets` stores and the `AssetServer`.
 use bevy::asset::{AssetPath, InvalidGenerationError};
 use bevy::prelude::*;
 
@@ -247,7 +248,7 @@ mod tests {
     use bevy::asset::LoadState;
 
     use super::*;
-    use crate::effects::command_insert_resource;
+    use crate::effects::command::command_insert_resource;
     use crate::prelude::affect;
 
     #[derive(Resource)]

--- a/src/effects/command.rs
+++ b/src/effects/command.rs
@@ -1,3 +1,4 @@
+//! [`Effect`]s that queue `Commands`.
 use std::marker::PhantomData;
 
 use bevy::prelude::*;

--- a/src/effects/entity_command.rs
+++ b/src/effects/entity_command.rs
@@ -1,3 +1,4 @@
+//! [`Effect`]s that queue entity-specific `Commands`.
 use std::marker::PhantomData;
 
 use bevy::ecs::error::CommandWithEntity;
@@ -271,8 +272,8 @@ mod tests {
     use proptest::prelude::*;
 
     use super::*;
+    use crate::effects::command::{command_insert_resource, command_spawn_and};
     use crate::effects::number_data::NumberComponent;
-    use crate::effects::{command_insert_resource, command_spawn_and};
     use crate::prelude::affect;
 
     proptest! {

--- a/src/effects/error.rs
+++ b/src/effects/error.rs
@@ -1,3 +1,7 @@
+//! [`Effect`]s for error handling.
+//!
+//! On top of the types shown here, this implements [`Effect`] for...
+//! - `Result<T, E>` where `T: Effect` and `E: Into<BevyError>`
 use bevy::ecs::error::{DefaultErrorHandler, ErrorContext};
 use bevy::ecs::system::{SystemChangeTick, SystemName};
 use bevy::prelude::*;
@@ -146,7 +150,8 @@ mod tests {
     use bevy::ecs::query::QuerySingleError;
 
     use super::*;
-    use crate::effects::{CommandSpawn, EntityCommandInsert, EntityCommandRemove, command_spawn};
+    use crate::effects::command::{CommandSpawn, command_spawn};
+    use crate::effects::entity_command::{EntityCommandInsert, EntityCommandRemove};
     use crate::prelude::affect;
 
     #[derive(Component)]

--- a/src/effects/iter.rs
+++ b/src/effects/iter.rs
@@ -1,3 +1,8 @@
+//! [`Effect`] implementations for generic iterators.
+//!
+//! On top of the types shown here, this implements [`Effect`] for...
+//! - `Vec<T>` where `T: Effect`
+//! - `Option<T>` where `T: Effect`
 use crate::Effect;
 
 /// [`Effect`] that causes all effects in the provided iterator.
@@ -89,8 +94,10 @@ mod tests {
     use bevy::prelude::*;
     use proptest::prelude::*;
 
+    use crate::effects::command::command_spawn;
+    use crate::effects::message::message_write;
     use crate::effects::number_data::NumberComponent;
-    use crate::effects::{command_spawn, message_write, res_set};
+    use crate::effects::resource::res_set;
     use crate::prelude::affect;
 
     proptest! {

--- a/src/effects/local.rs
+++ b/src/effects/local.rs
@@ -1,3 +1,4 @@
+//! [`Effect`]s that modify `Local` parameters.
 use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
 
@@ -71,7 +72,7 @@ mod tests {
     use crate::effect_out;
     use crate::effects::number_data::NumberResource;
     use crate::effects::one_way_fn::OneWayFn;
-    use crate::effects::res_set;
+    use crate::effects::resource::res_set;
     use crate::prelude::affect;
 
     proptest! {

--- a/src/effects/message.rs
+++ b/src/effects/message.rs
@@ -1,3 +1,4 @@
+//! [`Effect`]s that modify `MessageReader`s and `MessageWriter`s.
 use bevy::prelude::*;
 
 use crate::Effect;
@@ -94,7 +95,7 @@ mod tests {
 
     use super::*;
     use crate::effects::number_data::{NumberMessage, NumberResource};
-    use crate::effects::res_set_with;
+    use crate::effects::resource::res_set_with;
     use crate::prelude::affect;
 
     proptest! {

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -2,79 +2,28 @@
 //!
 //! [`Effect`]: crate::Effect
 
-mod resource;
-pub use resource::{ResSet, ResSetWith, res_set, res_set_with};
+pub mod resource;
 
-mod local;
-pub use local::{LocalSetAnd, local_set_and};
+pub mod local;
 
-mod message;
-pub use message::{MessageWrite, MessagesReadAnd, message_write, messages_read_and};
+pub mod message;
 
-mod command;
-pub use command::{
-    CommandInsertResource,
-    CommandQueue,
-    CommandRemoveResource,
-    CommandSpawn,
-    CommandSpawnAnd,
-    CommandTrigger,
-    command_insert_resource,
-    command_queue,
-    command_remove_resource,
-    command_spawn,
-    command_spawn_and,
-    command_trigger,
-};
+pub mod command;
 
-mod entity_command;
-pub use entity_command::{
-    EntityCommandDespawn,
-    EntityCommandInsert,
-    EntityCommandInsertRecursive,
-    EntityCommandQueue,
-    EntityCommandRemove,
-    EntityCommandRemoveRecursive,
-    entity_command_despawn,
-    entity_command_insert,
-    entity_command_insert_recursive,
-    entity_command_queue,
-    entity_command_remove,
-    entity_command_remove_recursive,
-};
+pub mod entity_command;
 
-mod query;
-pub use query::{QueryAffect, QueryMap, QueryMapAnd, query_affect, query_map, query_map_and};
+pub mod query;
 
-mod query_entity;
-pub use query_entity::{
-    QueryEntityAffect,
-    QueryEntityMap,
-    QueryEntityMapAnd,
-    query_entity_affect,
-    query_entity_map,
-    query_entity_map_and,
-};
+pub mod query_entity;
 
 #[cfg(feature = "asset_server")]
-mod asset_server;
-#[cfg(feature = "asset_server")]
-pub use asset_server::{
-    AssetAddAnd,
-    AssetInsert,
-    AssetServerLoadAnd,
-    asset_add_and,
-    asset_insert,
-    asset_server_load_and,
-};
+pub mod asset_server;
 
-mod algebra;
+pub mod algebra;
 
-mod iter;
-pub use iter::{AffectMany, affect_many};
+pub mod iter;
 
-mod error;
-pub use error::{AffectOrHandle, affect_or_handle};
+pub mod error;
 
 #[cfg(test)]
 mod one_way_fn;

--- a/src/effects/query.rs
+++ b/src/effects/query.rs
@@ -1,3 +1,4 @@
+//! [`Effect`]s that modify `Query` data.
 use std::marker::PhantomData;
 
 use bevy::ecs::query::{QueryData, QueryFilter, ReadOnlyQueryData};
@@ -143,7 +144,7 @@ where
 
 /// Type alias for the mapping function in [`QueryMap`] and [`QueryEntityMap`].
 ///
-/// [`QueryEntityMap`]: crate::effects::QueryEntityMap
+/// [`QueryEntityMap`]: crate::prelude::QueryEntityMap
 pub type BoxedQueryMapFn<QueryDataIn, QueryDataE> =
     Box<dyn for<'w, 's> Fn(<QueryDataIn as QueryData>::Item<'w, 's>) -> QueryDataE>;
 
@@ -311,7 +312,7 @@ where
 
 /// Type alias for the mapping function in [`QueryMapAnd`] and [`QueryEntityMapAnd`].
 ///
-/// [`QueryEntityMapAnd`]: crate::effects::QueryEntityMapAnd
+/// [`QueryEntityMapAnd`]: crate::prelude::QueryEntityMapAnd
 pub type BoxedQueryMapAndFn<QueryDataIn, E, QueryDataE> =
     Box<dyn for<'w, 's> Fn(<QueryDataIn as QueryData>::Item<'w, 's>) -> EffectOut<E, QueryDataE>>;
 

--- a/src/effects/query_entity.rs
+++ b/src/effects/query_entity.rs
@@ -1,3 +1,4 @@
+//! [`Effect`]s that modify `Query` data for particular entities.
 use std::marker::PhantomData;
 
 use bevy::ecs::query::{QueryFilter, ReadOnlyQueryData};

--- a/src/effects/resource.rs
+++ b/src/effects/resource.rs
@@ -1,3 +1,4 @@
+//! [`Effect`]s that modify resources.
 use std::any::type_name;
 use std::convert::identity;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //! None of these are enabled by default.
 //!
 //! [feature flags]: https://doc.rust-lang.org/cargo/reference/features.html#the-features-section
-//! [`AssetServer`-related effects]: effects::AssetServerLoadAnd
+//! [`AssetServer`-related effects]: effects::asset_server
 #![warn(missing_docs)]
 #![deny(rustdoc::all)]
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,66 +2,68 @@
 
 pub use either::Either;
 
-pub use crate::effects::{
-    AffectMany,
-    AffectOrHandle,
+pub use crate::effects::command::{
     CommandInsertResource,
     CommandQueue,
     CommandRemoveResource,
     CommandSpawn,
     CommandSpawnAnd,
     CommandTrigger,
-    EntityCommandDespawn,
-    EntityCommandInsert,
-    EntityCommandInsertRecursive,
-    EntityCommandQueue,
-    EntityCommandRemove,
-    EntityCommandRemoveRecursive,
-    LocalSetAnd,
-    MessageWrite,
-    MessagesReadAnd,
-    QueryAffect,
-    QueryEntityAffect,
-    QueryEntityMap,
-    QueryEntityMapAnd,
-    QueryMap,
-    QueryMapAnd,
-    ResSet,
-    ResSetWith,
-    affect_many,
-    affect_or_handle,
     command_insert_resource,
     command_queue,
     command_remove_resource,
     command_spawn,
     command_spawn_and,
     command_trigger,
+};
+pub use crate::effects::entity_command::{
+    EntityCommandDespawn,
+    EntityCommandInsert,
+    EntityCommandInsertRecursive,
+    EntityCommandQueue,
+    EntityCommandRemove,
+    EntityCommandRemoveRecursive,
     entity_command_despawn,
     entity_command_insert,
     entity_command_insert_recursive,
     entity_command_queue,
     entity_command_remove,
     entity_command_remove_recursive,
-    local_set_and,
+};
+pub use crate::effects::error::{AffectOrHandle, affect_or_handle};
+pub use crate::effects::iter::{AffectMany, affect_many};
+pub use crate::effects::local::{LocalSetAnd, local_set_and};
+pub use crate::effects::message::{
+    MessageWrite,
+    MessagesReadAnd,
     message_write,
     messages_read_and,
+};
+pub use crate::effects::query::{
+    QueryAffect,
+    QueryMap,
+    QueryMapAnd,
     query_affect,
+    query_map,
+    query_map_and,
+};
+pub use crate::effects::query_entity::{
+    QueryEntityAffect,
+    QueryEntityMap,
+    QueryEntityMapAnd,
     query_entity_affect,
     query_entity_map,
     query_entity_map_and,
-    query_map,
-    query_map_and,
-    res_set,
-    res_set_with,
 };
+pub use crate::effects::resource::{ResSet, ResSetWith, res_set, res_set_with};
 #[cfg(feature = "asset_server")]
 pub use crate::effects::{
-    AssetAddAnd,
-    AssetInsert,
-    AssetServerLoadAnd,
-    asset_add_and,
-    asset_insert,
-    asset_server_load_and,
+    asset_server::AssetAddAnd,
+    asset_server::AssetInsert,
+    asset_server::AssetServerLoadAnd,
+    asset_server::asset_add_and,
+    asset_server::asset_insert,
+    asset_server::asset_server_load_and,
 };
 pub use crate::query_data_effects::{ComponentSet, ComponentsSet, component_set, components_set};
 pub use crate::system_combinators::{


### PR DESCRIPTION
Closes #138

There's a little bit of an effect discoverability problem with the library at the moment. The `Effect` documentation lists them all, but it's polluted by tuple implementations and just lists effects alphabetically. The `effects` module implements them all, but it doesn't list the foreign implementations, and again, just lists effects alphabetically. This aims to make the `effects` module a more useful place to explore effects by organizing the effects into submodules, and for foreign types, mention them in the submodule docs. Actually, the effects are already organized this way in the source code, but re-exports and privatization were used to make their organization flatter. So, this simply undoes that pprivatization/re-exporting.
