### PR TITLE
fix!: rename asset_server feature to asset

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,15 +30,15 @@ blake2 = "0.10.6"
 
 [features]
 derive = ["bevy_pipe_affect_derive"]
-asset_server = ["bevy/bevy_asset"]
+asset = ["bevy/bevy_asset"]
 
 [[example]]
 name = "relationship"
-required-features = ["asset_server"]
+required-features = ["asset"]
 
 [[example]]
 name = "observer"
-required-features = ["asset_server"]
+required-features = ["asset"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/book/book.toml
+++ b/book/book.toml
@@ -11,4 +11,4 @@ after = ["links"]
 manifest_dir = "."
 externs = ["bevy", "bevy_pipe_affect"]
 # be careful about enabling more features as the test builds quickly exceed github runner disk sizes
-build_features = ["asset_server", "bevy/bevy_camera", "bevy/bevy_sprite", "bevy/bevy_audio"]
+build_features = ["asset", "bevy/bevy_camera", "bevy/bevy_sprite", "bevy/bevy_audio"]

--- a/src/effects/asset.rs
+++ b/src/effects/asset.rs
@@ -9,7 +9,7 @@ use crate::Effect;
 ///
 /// Can be constructed with [`asset_server_load_and`].
 ///
-/// *Requires the `asset_server` feature to be enabled.*
+/// *Requires the `asset` feature to be enabled.*
 #[derive(derive_more::Debug)]
 pub struct AssetServerLoadAnd<'a, A, E>
 where
@@ -25,7 +25,7 @@ where
 
 /// Construct a new [`AssetServerLoadAnd`] [`Effect`], with an extra effect using the `Handle<A>`.
 ///
-/// *Requires the `asset_server` feature to be enabled.*
+/// *Requires the `asset` feature to be enabled.*
 pub fn asset_server_load_and<'a, P, F, A, E>(path: P, f: F) -> AssetServerLoadAnd<'a, A, E>
 where
     P: Into<AssetPath<'a>>,
@@ -57,7 +57,7 @@ where
 ///
 /// Can be constructed with [`asset_add_and`].
 ///
-/// *Requires the `asset_server` feature to be enabled.*
+/// *Requires the `asset` feature to be enabled.*
 #[derive(derive_more::Debug)]
 pub struct AssetAddAnd<A, E>
 where
@@ -112,7 +112,7 @@ where
 ///
 /// Can be constructed with [`asset_insert`], which can conveniently convert from a `&Handle<A>`.
 ///
-/// *Requires the `asset_server` feature to be enabled.*
+/// *Requires the `asset` feature to be enabled.*
 ///
 /// # Example
 /// In this example, we have a custom `AnimationMap` asset for storing animation indices by name,

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -16,8 +16,8 @@ pub mod query;
 
 pub mod query_entity;
 
-#[cfg(feature = "asset_server")]
-pub mod asset_server;
+#[cfg(feature = "asset")]
+pub mod asset;
 
 pub mod algebra;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,12 +15,12 @@
 //! ## Feature flags
 //! This crate provides the following set of [feature flags]:
 //! - `derive`: enables the [`Effect`] derive macro for structs and enums of effects
-//! - `asset_server`: enables the `bevy/bevy_asset` feature and [`AssetServer`-related effects]
+//! - `asset`: enables the `bevy/bevy_asset` feature and [`Asset`-related effects]
 //!
 //! None of these are enabled by default.
 //!
 //! [feature flags]: https://doc.rust-lang.org/cargo/reference/features.html#the-features-section
-//! [`AssetServer`-related effects]: effects::asset_server
+//! [`Asset`-related effects]: effects::asset
 #![warn(missing_docs)]
 #![deny(rustdoc::all)]
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -56,14 +56,14 @@ pub use crate::effects::query_entity::{
     query_entity_map_and,
 };
 pub use crate::effects::resource::{ResSet, ResSetWith, res_set, res_set_with};
-#[cfg(feature = "asset_server")]
+#[cfg(feature = "asset")]
 pub use crate::effects::{
-    asset_server::AssetAddAnd,
-    asset_server::AssetInsert,
-    asset_server::AssetServerLoadAnd,
-    asset_server::asset_add_and,
-    asset_server::asset_insert,
-    asset_server::asset_server_load_and,
+    asset::AssetAddAnd,
+    asset::AssetInsert,
+    asset::AssetServerLoadAnd,
+    asset::asset_add_and,
+    asset::asset_insert,
+    asset::asset_server_load_and,
 };
 pub use crate::query_data_effects::{ComponentSet, ComponentsSet, component_set, components_set};
 pub use crate::system_combinators::{


### PR DESCRIPTION
Closes #140

The `asset_server` feature now enables effects that are not `AssetServer`-specific, but still related to assets. This renames the feature to be a little more general accordingly.
