### PR TITLE
docs: make shared command note a full section

### DIFF
--- a/src/effects/defer_command_note.md
+++ b/src/effects/defer_command_note.md
@@ -1,3 +1,5 @@
  
- *Note: `Command` effects only affect the command queue.
- The `World` modifications of the command only take place when the `apply_deferred` system runs.*
+ # Command Note
+ `Command` effects only affect the command queue.
+ The `World` modifications of the command only take place when the
+ `apply_deferred` system runs, not immediately.


### PR DESCRIPTION
Now that all the command effects have a section for a code example, the existing command note kind of looks like it's associated with the code example. Giving it its own section makes it seem independent again (which it should be).
