### PR TITLE
example: spawn camera in rainbow-clear-color example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ fn main() -> AppExit {
             pure(rainbow_clear_color) // pure() is optional, just forces the system to be read-only
                 .pipe(affect),
         )
+        .add_systems(
+            Startup,
+            // The `CommandSpawn` effect's `default` function is technically a "system with effect"
+            CommandSpawn::<Camera2d>::default.pipe(affect),
+        )
         .run()
 }
 

--- a/examples/rainbow-clear-color.rs
+++ b/examples/rainbow-clear-color.rs
@@ -9,6 +9,11 @@ fn main() -> AppExit {
             pure(rainbow_clear_color) // pure() is optional, just forces the system to be read-only
                 .pipe(affect),
         )
+        .add_systems(
+            Startup,
+            // The `CommandSpawn` effect's `default` function is technically a "system with effect"
+            CommandSpawn::<Camera2d>::default.pipe(affect),
+        )
         .run()
 }
 


### PR DESCRIPTION
The rainbow-clear-color example was broken, likely after the upgrade to 0.18. It seems after a couple updates, the `ClearColor` needs a `Camera` to exist to work properly. This adds a camera to the example in a somewhat show-offy way.
