### PR TITLE
docs: add pure/impure examples to remaining asset effects

### DIFF
--- a/src/effects/asset.rs
+++ b/src/effects/asset.rs
@@ -58,6 +58,94 @@ where
 /// Can be constructed with [`asset_add_and`].
 ///
 /// *Requires the `asset` feature to be enabled.*
+///
+/// # Example
+/// In this example, we have a custom `AnimationMap` asset for storing animation indices by name,
+/// and a system is written that adds a player animation map to the asset store and stores it in a
+/// resource.
+/// ```
+/// use std::collections::HashMap;
+/// use std::ops::Range;
+///
+/// use bevy::prelude::*;
+/// use bevy_pipe_affect::prelude::*;
+///
+/// #[derive(Default, Debug, PartialEq, Eq, Reflect, Asset, Clone)]
+/// struct AnimationMap(HashMap<String, Range<usize>>);
+///
+/// #[derive(Debug, PartialEq, Eq, Resource)]
+/// struct PlayerAnimationsHandle(Handle<AnimationMap>);
+///
+/// fn base_player_animation_map() -> AnimationMap {
+///     AnimationMap(HashMap::from_iter([
+///         ("idle".to_string(), 0..1),
+///         ("running".to_string(), 1..5),
+///     ]))
+/// }
+///
+/// /// Pure system using effects.
+/// fn init_player_animations_pure()
+/// -> AssetAddAnd<AnimationMap, CommandInsertResource<PlayerAnimationsHandle>> {
+///     asset_add_and(base_player_animation_map(), |handle| {
+///         command_insert_resource(PlayerAnimationsHandle(handle))
+///     })
+/// }
+///
+/// /// Equivalent impure system.
+/// fn init_player_animations_impure(
+///     mut assets: ResMut<Assets<AnimationMap>>,
+///     mut commands: Commands,
+/// ) {
+///     let handle = assets.add(base_player_animation_map());
+///     commands.insert_resource(PlayerAnimationsHandle(handle));
+/// }
+/// #
+/// # fn app_setup() -> App {
+/// #     let mut app = App::new();
+/// #
+/// #     app.add_plugins(AssetPlugin::default())
+/// #         .init_asset::<AnimationMap>();
+/// #
+/// #     app
+/// # }
+/// #
+/// # fn test_state(
+/// #     world: &World,
+/// # ) -> (
+/// #     Vec<(AssetId<AnimationMap>, &AnimationMap)>,
+/// #     Option<&PlayerAnimationsHandle>,
+/// # ) {
+/// #     let all_assets = world
+/// #         .get_resource::<Assets<AnimationMap>>()
+/// #         .unwrap()
+/// #         .iter()
+/// #         .collect();
+/// #     let resource = world.get_resource::<PlayerAnimationsHandle>();
+/// #
+/// #     (all_assets, resource)
+/// # }
+/// #
+/// # fn main() {
+/// #     let mut pure_app = app_setup();
+/// #     pure_app.add_systems(Update, init_player_animations_pure.pipe(affect));
+/// #
+/// #     let mut impure_app = app_setup();
+/// #     impure_app.add_systems(Update, init_player_animations_impure);
+/// #
+/// #     for _ in 0..3 {
+/// #         assert_eq!(
+/// #             test_state(pure_app.world_mut()),
+/// #             test_state(impure_app.world_mut())
+/// #         );
+/// #         pure_app.update();
+/// #         impure_app.update();
+/// #     }
+/// # }
+/// ```
+///
+/// Not shown...
+/// - in this example, `CommandInsertResource` is used as the additional [`Effect`], but other
+/// [`Effect`]s are available.
 #[derive(derive_more::Debug)]
 pub struct AssetAddAnd<A, E>
 where

--- a/src/effects/asset.rs
+++ b/src/effects/asset.rs
@@ -66,8 +66,8 @@ use crate::Effect;
 /// ```
 ///
 /// Not shown...
-/// - In this example, a `CommandSpawn` is used as the additional [`Effect`], but other
-/// [`Effect`]s are available.
+/// - in this example, a `CommandSpawn` is used as the additional [`Effect`], but other
+///   [`Effect`]s are available.
 #[derive(derive_more::Debug)]
 pub struct AssetServerLoadAnd<'a, A, E>
 where
@@ -203,7 +203,7 @@ where
 ///
 /// Not shown...
 /// - in this example, `CommandInsertResource` is used as the additional [`Effect`], but other
-/// [`Effect`]s are available.
+///   [`Effect`]s are available.
 #[derive(derive_more::Debug)]
 pub struct AssetAddAnd<A, E>
 where

--- a/src/effects/asset.rs
+++ b/src/effects/asset.rs
@@ -10,6 +10,64 @@ use crate::Effect;
 /// Can be constructed with [`asset_server_load_and`].
 ///
 /// *Requires the `asset` feature to be enabled.*
+///
+/// # Example
+/// In this example, a system is written that spawns a sprite with the "player.png" image.
+/// ```
+/// use bevy::prelude::*;
+/// use bevy_pipe_affect::prelude::*;
+///
+/// fn spawn_player_pure() -> AssetServerLoadAnd<'static, Image, CommandSpawn<Sprite>> {
+///     asset_server_load_and("player.png", |handle| {
+///         command_spawn(Sprite::from_image(handle))
+///     })
+/// }
+///
+/// fn spawn_player_impure(asset_server: Res<AssetServer>, mut commands: Commands) {
+///     let handle = asset_server.load("player.png");
+///     commands.spawn(Sprite::from_image(handle));
+/// }
+/// #
+/// # fn app_setup() -> App {
+/// #     let mut app = App::new();
+/// #     app.add_plugins((
+/// #         MinimalPlugins,
+/// #         AssetPlugin::default(),
+/// #         ImagePlugin::default_linear(),
+/// #     ));
+/// #
+/// #     app
+/// # }
+/// #
+/// # fn test_state(world: &mut World) -> Vec<(Entity, Option<Handle<Image>>)> {
+/// #     let mut query = world.query::<(Entity, Option<&Sprite>)>();
+/// #     query
+/// #         .iter(world)
+/// #         .map(|(entity, sprite)| (entity, sprite.map(|sprite| sprite.image.clone())))
+/// #         .collect()
+/// # }
+/// #
+/// # fn main() {
+/// #     let mut pure_app = app_setup();
+/// #     pure_app.add_systems(Update, spawn_player_pure.pipe(affect));
+/// #
+/// #     let mut impure_app = app_setup();
+/// #     impure_app.add_systems(Update, spawn_player_impure);
+/// #
+/// #     for _ in 0..3 {
+/// #         assert_eq!(
+/// #             test_state(pure_app.world_mut()),
+/// #             test_state(impure_app.world_mut())
+/// #         );
+/// #         pure_app.update();
+/// #         impure_app.update();
+/// #     }
+/// # }
+/// ```
+///
+/// Not shown...
+/// - In this example, a `CommandSpawn` is used as the additional [`Effect`], but other
+/// [`Effect`]s are available.
 #[derive(derive_more::Debug)]
 pub struct AssetServerLoadAnd<'a, A, E>
 where


### PR DESCRIPTION
Comparing a pure system to the equivalent impure system is instructive, and their equivalence is a nice property to test. This change adds a pure/impure example and proptest to the remaining `asset` effects.
