### PR TITLE
docs: standardize pure/impure example system doc comments

### DIFF
--- a/src/effects/asset.rs
+++ b/src/effects/asset.rs
@@ -17,12 +17,14 @@ use crate::Effect;
 /// use bevy::prelude::*;
 /// use bevy_pipe_affect::prelude::*;
 ///
+/// /// Pure system using effects.
 /// fn spawn_player_pure() -> AssetServerLoadAnd<'static, Image, CommandSpawn<Sprite>> {
 ///     asset_server_load_and("player.png", |handle| {
 ///         command_spawn(Sprite::from_image(handle))
 ///     })
 /// }
 ///
+/// /// Equivalent impure system.
 /// fn spawn_player_impure(asset_server: Res<AssetServer>, mut commands: Commands) {
 ///     let handle = asset_server.load("player.png");
 ///     commands.spawn(Sprite::from_image(handle));

--- a/src/effects/command.rs
+++ b/src/effects/command.rs
@@ -216,10 +216,12 @@ where
 /// # #[derive(proptest_derive::Arbitrary)]
 /// struct GoToLevel(usize);
 ///
+/// /// Pure system using effects.
 /// fn complete_level_transition_pure() -> CommandRemoveResource<GoToLevel> {
 ///     command_remove_resource::<GoToLevel>()
 /// }
 ///
+/// /// Equivalent impure system.
 /// fn complete_level_transition_impure(mut commands: Commands) {
 ///     commands.remove_resource::<GoToLevel>()
 /// }

--- a/src/effects/entity_command.rs
+++ b/src/effects/entity_command.rs
@@ -29,6 +29,7 @@ use crate::Effect;
 /// #[derive(Copy, Clone, Debug, PartialEq, Eq, Component)]
 /// struct Player;
 ///
+/// /// Pure system using effects.
 /// fn reset_player_pure(
 ///     player: Single<Entity, With<Player>>,
 /// ) -> EntityCommandQueue<
@@ -39,6 +40,7 @@ use crate::Effect;
 ///     entity_command_queue(*player, retain::<Player>())
 /// }
 ///
+/// /// Equivalent impure system.
 /// fn reset_player_impure(player: Single<Entity, With<Player>>, mut commands: Commands) {
 ///     commands.entity(*player).retain::<Player>();
 /// }

--- a/src/effects/query.rs
+++ b/src/effects/query.rs
@@ -28,12 +28,12 @@ use crate::{Effect, EffectOut, effect_out};
 /// # #[derive(proptest_derive::Arbitrary)]
 /// struct Brake;
 ///
-/// // Pure system using effects.
+/// /// Pure system using effects.
 /// fn stop_all_pure() -> QueryAffect<ComponentSet<Speed>, With<Brake>> {
 ///     query_affect(component_set(Speed(0.0)))
 /// }
 ///
-/// // Equivalent impure system.
+/// /// Equivalent impure system.
 /// fn stop_all_impure(mut query: Query<&mut Speed, With<Brake>>) {
 ///     for (mut number_component) in query.iter_mut() {
 ///         *number_component = Speed(0.0);
@@ -170,14 +170,14 @@ pub type BoxedQueryMapFn<QueryDataIn, QueryDataE> =
 /// # #[derive(proptest_derive::Arbitrary)]
 /// struct Speed(f32);
 ///
-/// // Pure system using effects.
+/// /// Pure system using effects.
 /// fn accelerate_pure() -> QueryMap<(&'static Acceleration, &'static Speed), ComponentSet<Speed>> {
 ///     query_map(move |(acceleration, speed): (&Acceleration, &Speed)| {
 ///         component_set(Speed(speed.0 + acceleration.0))
 ///     })
 /// }
 ///
-/// // Equivalent impure system.
+/// /// Equivalent impure system.
 /// fn accelerate_impure(mut query: Query<(&Acceleration, &mut Speed)>) {
 ///     for (acceleration, mut speed) in query.iter_mut() {
 ///         speed.0 += acceleration.0


### PR DESCRIPTION
Most pure/impure examples have doc comments above the relevant systems like..
```
/// Pure system using effects.
...

/// Equivalent impure system.
...
```

Some were missed, or were slightly different. This change standardizes them across the board.
