### PR TITLE
docs: add pure/impure example to AffectMany

### DIFF
--- a/src/effects/iter.rs
+++ b/src/effects/iter.rs
@@ -10,6 +10,51 @@ use crate::Effect;
 /// Using a plain `Vec` or `Option` as an effect works too.
 ///
 /// Can be constructed with [`affect_many`].
+///
+/// # Example
+/// In this example, a system is written that spawns 20 empty entities.
+/// ```
+/// use bevy::prelude::*;
+/// use bevy_pipe_affect::prelude::*;
+///
+/// /// Pure system using effects.
+/// fn spawn_20_pure() -> AffectMany<std::iter::RepeatN<CommandSpawn<()>>> {
+///     affect_many(std::iter::repeat_n(command_spawn(()), 20))
+/// }
+///
+/// /// Equivalent impure system.
+/// fn spawn_20_impure(mut commands: Commands) {
+///     for _ in 0..20 {
+///         commands.spawn_empty();
+///     }
+/// }
+/// #
+/// # fn app_setup() -> App {
+/// #     App::new()
+/// # }
+/// #
+/// # fn test_state(world: &mut World) -> Vec<Entity> {
+/// #     let mut query = world.query::<Entity>();
+/// #     query.iter(world).collect()
+/// # }
+/// #
+/// # fn main() {
+/// #     let mut pure_app = app_setup();
+/// #     pure_app.add_systems(Update, spawn_20_pure.pipe(affect));
+/// #
+/// #     let mut impure_app = app_setup();
+/// #     impure_app.add_systems(Update, spawn_20_impure);
+/// #
+/// #     for _ in 0..3 {
+/// #         assert_eq!(
+/// #             test_state(pure_app.world_mut()),
+/// #             test_state(impure_app.world_mut())
+/// #         );
+/// #         pure_app.update();
+/// #         impure_app.update();
+/// #     }
+/// # }
+/// ```
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct AffectMany<I>
 where


### PR DESCRIPTION
Comparing a pure system to the equivalent impure system is instructive, and their equivalence is a nice property to test. This change adds a pure/impure example and proptest to `AffectMany`.
