### PR TITLE
docs: encourage users to explore the effects module

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Documentation for this library is available in two main places.
 
 The following are good jumping-off points for beginners:
 - [*Motivations* explanation](https://trouv.github.io/bevy_pipe_affect/v0.2.0/explanation/motivations.html) <!-- x-release-please-version -->
-- [*effects* module api reference](https://docs.rs/bevy_pipe_affect/0.2.0/bevy_pipe_affect/effects/index.html) (a list of effects and constructors provided by the library) <!-- x-release-please-version -->
+- [*effects* module api reference](https://docs.rs/bevy_pipe_affect/0.2.0/bevy_pipe_affect/effects/index.html) (discover what effects are available, with examples!) <!-- x-release-please-version -->
 
 Cargo examples are also available in this repository:
 ```sh

--- a/book/src/README.md
+++ b/book/src/README.md
@@ -19,7 +19,7 @@ Splitting the documentation up this way means that docs are not necessarily mean
 Some chapters are intended to be read while working on your own project, while others are meant to be more like studying material.
 The following are good jumping-off points for beginners:
 - [*Motivations* explanation](explanation/motivations.md)
-- [*effects* module api reference](https://docs.rs/bevy_pipe_affect/0.2.0/bevy_pipe_affect/effects/index.html) (a list of effects and constructors provided by the library) <!-- x-release-please-version -->
+- [*effects* module api reference](https://docs.rs/bevy_pipe_affect/0.2.0/bevy_pipe_affect/effects/index.html) (discover what effects are available, with examples!) <!-- x-release-please-version -->
 
 ## Other resources
 This book is not suitable documentation for Bevy.

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -1,4 +1,10 @@
-//! [`Effect`] implementors.
+//! [`Effect`] implementors and their constructors.
+//!
+//! Exploring this module is an easy way to discover what effects are available!
+//! The effects are roughly organized by the system parameter they mutate.
+//!
+//! All of the native effect types have code examples, typically comparing a system that uses them
+//! to an equivalent impure system.
 //!
 //! [`Effect`]: crate::Effect
 


### PR DESCRIPTION
The `effects` module is now organized better in the api reference, and completely fleshed out with code examples. The book and README of the library already link to this module as a good place to discover effects, however, the module doc is a bit underwhelming. This changes the module doc to encourage users to explore, and explains the organization and code examples.
