### PR TITLE
docs: link cargo examples to effects module

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,10 @@
+# cargo examples
+This directory contains some cargo examples of using `bevy_pipe_affect` in basic bevy apps.
+Clone the repo and run examples like:
+```sh
+$ cargo run --release --all-features --example example-name
+```
+
+Note that these cargo examples do not demonstrate complete coverage of `bevy_pipe_affect`'s features; they do not even demonstrate all of the `Effect` implementors.
+For more code examples of `Effect`s, please explore the [`effects` module api reference](https://docs.rs/bevy_pipe_affect/0.3.0/bevy_pipe_affect/effects/index.html). <!-- x-release-please-version -->
+This is a good resource to discover what `Effect`s are available, and code examples are provided for all of them.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,7 +12,8 @@
         "README.md",
         "book/src/README.md",
         "book/src/api-reference.md",
-        "src/lib.rs"
+        "src/lib.rs",
+        "examples/README.md"
       ],
       "changelog-sections": [
         {"type": "feat", "section": "Features"},


### PR DESCRIPTION
The coverage of code examples for effects is actually quite good, but it is not in the `examples` directory like some users may expect. Instead, they are doc examples in the cargo docs. This change adds a `README.md` to the examples directory to help guide users towards the effects module doc examples.
