### PR TITLE
docs: add 0.4 to compatibility chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ $ cargo run --release --all-features --example example-name
 ## Compatibility
 | bevy | bevy_pipe_affect |
 | --- | --- |
-| 0.19 | main |
+| 0.19 | 0.4 |
 | 0.18 | 0.3 |
 | 0.18 | 0.2 |
 | 0.17 | 0.1 |


### PR DESCRIPTION
0.4 is ready to release. The compatibility chart needs to be manually updated accordingly.
